### PR TITLE
Matlab library: replace logical bit-wise operators 

### DIFF
--- a/src/matlab/CheckBrikHEAD.m
+++ b/src/matlab/CheckBrikHEAD.m
@@ -81,7 +81,7 @@ for (ir = 1:1:N_Rules),
 					err = 1; ErrMessage = sprintf('Error %s: Field %s type (string or numerical) is wrong.', FuncName, Rules(ir).Name);warndlg(ErrMessage);return;
 				end
 			else %a number, verify type
-				if (Rules(ir).isNum == 1 & ~isint(getfield(Info, Rules(ir).Name))),
+				if (Rules(ir).isNum == 1 && ~isint(getfield(Info, Rules(ir).Name))),
 					err = 1; ErrMessage = sprintf('Error %s: Field %s type must be an integer.', FuncName, Rules(ir).Name);
 				end
 			end
@@ -130,17 +130,17 @@ end
 			err = 1; ErrMessage = sprintf('Error %s: TYPESTRING must be one of \n3DIM_HEAD_ANAT, 3DIM_HEAD_FUNC, 3DIM_GEN_ANAT or 3DIM_GEN_FUNC', FuncName); errordlg(ErrMessage); return;	
 		end
 
-		if (Info.SCENE_DATA(1) < 0 |  Info.SCENE_DATA(1) > 2),
+		if (Info.SCENE_DATA(1) < 0 ||  Info.SCENE_DATA(1) > 2),
 			err = 1; ErrMessage = sprintf('Error %s: SCENE_DATA(1) must be between 0 and 2', FuncName); errordlg(ErrMessage); return;
 		end
-		if (Info.SCENE_DATA(2) < 0 |  Info.SCENE_DATA(2) > 11),
+		if (Info.SCENE_DATA(2) < 0 ||  Info.SCENE_DATA(2) > 11),
 			err = 1; ErrMessage = sprintf('Error %s: SCENE_DATA(2) must be between 0 and 11', FuncName); errordlg(ErrMessage); return;
 		end
-		if (Info.SCENE_DATA(3) < 0 |  Info.SCENE_DATA(3) > 3),
+		if (Info.SCENE_DATA(3) < 0 ||  Info.SCENE_DATA(3) > 3),
 			err = 1; ErrMessage = sprintf('Error %s: SCENE_DATA(3) must be between 0 and 3', FuncName); errordlg(ErrMessage); return;
 		end
 
-		if (Info.ORIENT_SPECIFIC(1) < 0 |  Info.ORIENT_SPECIFIC(1) > 5),
+		if (Info.ORIENT_SPECIFIC(1) < 0 ||  Info.ORIENT_SPECIFIC(1) > 5),
 			err = 1; ErrMessage = sprintf('Error %s: ORIENT_SPECIFIC(1) must be between 0 and 5', FuncName); errordlg(ErrMessage); return;
 		end
 
@@ -173,7 +173,7 @@ end
 				err = 1; ErrMessage = sprintf('Error %s: TAXIS_NUMS(1) must be equal to DATASET_RANK(2)', FuncName); errordlg(ErrMessage); return;
 			end
 
-			if (Info.TAXIS_NUMS(2) & (~isfield(Info,'TAXIS_OFFSETS') | isempty(Info.TAXIS_OFFSETS))),
+			if (Info.TAXIS_NUMS(2) && (~isfield(Info,'TAXIS_OFFSETS') || isempty(Info.TAXIS_OFFSETS))),
 				err = 1; ErrMessage = sprintf('Error %s: TAXIS_OFFSETS must have a value if TAXIS_NUMS(2) is != 0', FuncName); errordlg(ErrMessage); return;
 			end
 		end
@@ -185,7 +185,7 @@ end
 		end
 
 		if (isfield(Info, 'BYTEORDER_STRING')),
-			if (~strcmp(Info.BYTEORDER_STRING, 'LSB_FIRST') & ~strcmp(Info.BYTEORDER_STRING, 'MSB_FIRST')),
+			if (~strcmp(Info.BYTEORDER_STRING, 'LSB_FIRST') && ~strcmp(Info.BYTEORDER_STRING, 'MSB_FIRST')),
 				err = 1; ErrMessage = sprintf('Error %s: BYTEORDER_STRING must be either MSB_FIRST or LSB_FIRST', FuncName); errordlg(ErrMessage); return;
 			end
 		end
@@ -200,11 +200,11 @@ end
          end	
       end
 
-		if (isfield(Info, 'NOTES_COUNT') & (Info.NOTES_COUNT < 0 | Info.NOTES_COUNT > 999)),
+		if (isfield(Info, 'NOTES_COUNT') && (Info.NOTES_COUNT < 0 || Info.NOTES_COUNT > 999)),
 			err = 1; ErrMessage = sprintf('Error %s: NOTES_COUNT must be between 0 and 999.', FuncName); errordlg(ErrMessage); return;
 		end
 
-		if (isfield(Info, 'WARP_TYPE') & (Info.WARP_TYPE(1) ~= 0 & Info.WARP_TYPE(1) ~= 1)),
+		if (isfield(Info, 'WARP_TYPE') && (Info.WARP_TYPE(1) ~= 0 && Info.WARP_TYPE(1) ~= 1)),
 			err = 1; ErrMessage = sprintf('Error %s: WARP_TYPE(1) must be 0 or 1.', FuncName); errordlg(ErrMessage); return;
 		end
 
@@ -215,7 +215,7 @@ end
 		end
 
 		if (isfield(Info, 'MARKS_FLAGS')),
-			if (Info.MARKS_FLAGS(1) ~= 1 & Info.MARKS_FLAGS(1) ~= 2),
+			if (Info.MARKS_FLAGS(1) ~= 1 && Info.MARKS_FLAGS(1) ~= 2),
 				err = 1; ErrMessage = sprintf('Error %s: MARKS_FLAGS(1) must be 0 or 1.', FuncName); errordlg(ErrMessage); return;	
 			end
 			if (Info.MARKS_FLAGS(2) ~= 1),
@@ -229,13 +229,13 @@ end
 			end
 		end
 
-		if (isfield(Info, 'TAGSET_NUM') & isfield(Info, 'TAGSET_FLOATS')),
+		if (isfield(Info, 'TAGSET_NUM') && isfield(Info, 'TAGSET_FLOATS')),
 			if (length(Info.TAGSET_FLOATS) ~= (Info.TAGSET_NUM(1) .* Info.TAGSET_NUM(2)) ),   % Ask Ziad about this later
 				err = 1; ErrMessage = sprintf('Error %s: Length of TAGSET_FLOATS must equal TAGSET_NUM(1) * TAGSET_NUM(2).', FuncName); errordlg(ErrMessage); return;	
 			end
 		end
 
-		if (isfield(Info, 'TAGSET_NUM') & isfield(Info, 'TAGSET_LABELS')),
+		if (isfield(Info, 'TAGSET_NUM') && isfield(Info, 'TAGSET_LABELS')),
 			if (WordCount(Info.TAGSET_LABELS, '~') ~= Info.TAGSET_NUM(1)),   % Ask Ziad later
 				err = 1; ErrMessage = sprintf('Error %s: TAGSET_LABELS must contain TAGSET_NUM(1) ~ delimited strings.', FuncName); errordlg(ErrMessage); return;	
 			end
@@ -259,7 +259,7 @@ end
 		end
 
 		%check on the NOT_NUMBER_... fields
-		if (~isfield(Info, 'NOTES_COUNT') & isfield(Info, 'NOTE_NUMBER_001')),
+		if (~isfield(Info, 'NOTES_COUNT') && isfield(Info, 'NOTE_NUMBER_001')),
 			Info = rmfield(Info, 'NOTE_NUMBER_001');
 		end
 

--- a/src/matlab/WriteBrikHEAD.m
+++ b/src/matlab/WriteBrikHEAD.m
@@ -144,11 +144,11 @@ for (i=1:1:Fld_num),
 			err = 1; ErrMessage = sprintf('Error %s: RulesType %d unknown.', FuncName, RulesType); errordlg(ErrMessage); return;
 	end			
 	%write them out
-	if (RulesType >=0 | Fld_Count > 0),
+    if (RulesType >=0 || Fld_Count > 0),
       fprintf(fidout,'\ntype = %s\n', Fld_Type);
 	   fprintf(fidout,'name = %s\n', Fld_Name);
 	   fprintf(fidout,'count = %g\n', Fld_Count);
-	   if(Fld_isstrn),
+       if(Fld_isstrn),
 		   %string to write out, do what Bob seems to do
 		   stmp = sprintf('''%s~',Fld_Val);
 		   fprintf(fidout,'%s\n', stmp);
@@ -159,12 +159,14 @@ for (i=1:1:Fld_num),
 		   Fld_Val = reshape(Fld_Val, npts, 1);
 		   %print out 5 values per line
 		   fprintf(fidout, '\t%g\t%g\t%g\t%g\t%g\n', Fld_Val);
-		   if (rem(npts,5)), fprintf(fidout,'\n'); end
-	   end
-   else
+		   if (rem(npts,5))
+               fprintf(fidout,'\n');
+           end
+       end
+    else
       %Skip those empty fields. Including empty WORSLEY_* attributes
       %was causing scaling factors to be ignored ...
-   end
+    end
 end
 
 fclose (fidout);


### PR DESCRIPTION
Make the Matlab library more compatible with GNU Octave by replacing logical bit-wise operators ('&' and '|') by the short-circuit versions ('&&' and '||').