### PR TITLE
ENH: Add `choose` and `ifelse` to ccalc and friends

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -9,19 +9,19 @@
 
 static integer c__3 = 3;
 static integer c__1 = 1;
-static doublereal c_b422 = 0.;
-static doublereal c_b436 = 1.;
-static doublereal c_b437 = 2.;
-static doublereal c_b438 = 3.;
-static doublereal c_b439 = 4.;
-static doublereal c_b440 = 5.;
-static doublereal c_b441 = 6.;
-static doublereal c_b442 = 7.;
-static doublereal c_b443 = 8.;
-static doublereal c_b444 = 9.;
-static doublereal c_b445 = 10.;
-static doublereal c_b446 = 11.;
-static doublereal c_b447 = 12.;
+static doublereal c_b424 = 0.;
+static doublereal c_b438 = 1.;
+static doublereal c_b439 = 2.;
+static doublereal c_b440 = 3.;
+static doublereal c_b441 = 4.;
+static doublereal c_b442 = 5.;
+static doublereal c_b443 = 6.;
+static doublereal c_b444 = 7.;
+static doublereal c_b445 = 8.;
+static doublereal c_b446 = 9.;
+static doublereal c_b447 = 10.;
+static doublereal c_b448 = 11.;
+static doublereal c_b449 = 12.;
 
 /* Subroutine */ int parser_(char *c_expr__, logical *l_print__, integer *
 	num_code__, char *c_code__, ftnlen c_expr_len, ftnlen c_code_len)
@@ -2030,28 +2030,29 @@ L8000:
     extern doublereal qg_(doublereal *), median_(integer *, doublereal *), 
 	    argmax_(integer *, doublereal *), pairmn_(integer *, doublereal *)
 	    , amongf_(integer *, doublereal *), argnum_(integer *, doublereal 
-	    *), ficotp_(doublereal *, doublereal *, doublereal *, doublereal *
-	    ), ficopt_(doublereal *, doublereal *, doublereal *, doublereal *)
-	    , fifttp_(doublereal *, doublereal *, doublereal *), ficotz_(
-	    doublereal *, doublereal *, doublereal *, doublereal *), fiftpt_(
-	    doublereal *, doublereal *, doublereal *), pairmx_(integer *, 
-	    doublereal *), ficttp_(doublereal *, doublereal *), fictpt_(
-	    doublereal *, doublereal *), ficttz_(doublereal *, doublereal *), 
-	    posval_(doublereal *), fibttp_(doublereal *, doublereal *, 
-	    doublereal *), fifttz_(doublereal *, doublereal *, doublereal *), 
-	    fibtpt_(doublereal *, doublereal *, doublereal *), fibttz_(
-	    doublereal *, doublereal *, doublereal *), fitttp_(doublereal *, 
-	    doublereal *), fittpt_(doublereal *, doublereal *), orstat_(
-	    integer *, integer *, doublereal *), fibntp_(doublereal *, 
-	    doublereal *, doublereal *), absextreme_(integer *, doublereal *),
-	     fibnpt_(doublereal *, doublereal *, doublereal *), fizttp_(
-	    doublereal *), fiztpt_(doublereal *), fibntz_(doublereal *, 
-	    doublereal *, doublereal *), figttp_(doublereal *, doublereal *, 
-	    doublereal *), fitttz_(doublereal *, doublereal *), figtpt_(
-	    doublereal *, doublereal *, doublereal *), figttz_(doublereal *, 
-	    doublereal *, doublereal *), fipttp_(doublereal *, doublereal *), 
-	    fiptpt_(doublereal *, doublereal *), fipttz_(doublereal *, 
-	    doublereal *), fizttz_(doublereal *), cbrtff_(doublereal *);
+	    *), choose_(integer *, integer *, doublereal *), ficotp_(
+	    doublereal *, doublereal *, doublereal *, doublereal *), ficopt_(
+	    doublereal *, doublereal *, doublereal *, doublereal *), fifttp_(
+	    doublereal *, doublereal *, doublereal *), ficotz_(doublereal *, 
+	    doublereal *, doublereal *, doublereal *), fiftpt_(doublereal *, 
+	    doublereal *, doublereal *), pairmx_(integer *, doublereal *), 
+	    ficttp_(doublereal *, doublereal *), fictpt_(doublereal *, 
+	    doublereal *), ficttz_(doublereal *, doublereal *), posval_(
+	    doublereal *), fibttp_(doublereal *, doublereal *, doublereal *), 
+	    fifttz_(doublereal *, doublereal *, doublereal *), fibtpt_(
+	    doublereal *, doublereal *, doublereal *), fibttz_(doublereal *, 
+	    doublereal *, doublereal *), fitttp_(doublereal *, doublereal *), 
+	    fittpt_(doublereal *, doublereal *), orstat_(integer *, integer *,
+	     doublereal *), fibntp_(doublereal *, doublereal *, doublereal *),
+	     absextreme_(integer *, doublereal *), fibnpt_(doublereal *, 
+	    doublereal *, doublereal *), fizttp_(doublereal *), fiztpt_(
+	    doublereal *), fibntz_(doublereal *, doublereal *, doublereal *), 
+	    figttp_(doublereal *, doublereal *, doublereal *), fitttz_(
+	    doublereal *, doublereal *), figtpt_(doublereal *, doublereal *, 
+	    doublereal *), figttz_(doublereal *, doublereal *, doublereal *), 
+	    fipttp_(doublereal *, doublereal *), fiptpt_(doublereal *, 
+	    doublereal *), fipttz_(doublereal *, doublereal *), fizttz_(
+	    doublereal *), cbrtff_(doublereal *);
     static doublereal r8_eval__[6464]	/* was [64][101] */;
     extern doublereal dai_(doublereal *), dbi_(doublereal *, integer *), mad_(
 	    integer *, doublereal *);
@@ -3274,6 +3275,33 @@ L1000:
 		r8_eval__[iv - ibv + (neval << 6) - 65] = absextreme_(&ntm, 
 			scop);
 	    }
+	} else if (s_cmp(cncode, "CHOOSE", 8L, 6L) == 0) {
+	    ntm = (integer) r8_eval__[(neval << 6) - 64];
+	    neval -= ntm;
+	    --ntm;
+	    i__2 = ivtop;
+	    for (iv = ivbot; iv <= i__2; ++iv) {
+		itm = (integer) r8_eval__[iv - ibv + (neval << 6) - 65];
+		i__3 = ntm;
+		for (jtm = 1; jtm <= i__3; ++jtm) {
+		    scop[jtm - 1] = r8_eval__[iv - ibv + (neval + jtm << 6) - 
+			    65];
+		}
+		r8_eval__[iv - ibv + (neval << 6) - 65] = choose_(&itm, &ntm, 
+			scop);
+	    }
+	} else if (s_cmp(cncode, "IFELSE", 8L, 6L) == 0) {
+	    neval += -2;
+	    i__2 = ivtop;
+	    for (iv = ivbot; iv <= i__2; ++iv) {
+		if (r8_eval__[iv - ibv + (neval << 6) - 65] != 0.) {
+		    r8_eval__[iv - ibv + (neval << 6) - 65] = r8_eval__[iv - 
+			    ibv + (neval + 1 << 6) - 65];
+		} else {
+		    r8_eval__[iv - ibv + (neval << 6) - 65] = r8_eval__[iv - 
+			    ibv + (neval + 2 << 6) - 65];
+		}
+	    }
 /* ...............................................................
 ........ */
 	} else if (s_cmp(cncode, "FICO_T2P", 8L, 8L) == 0) {
@@ -3663,7 +3691,7 @@ doublereal iran_(doublereal *top)
 /*  Return an integer uniformly distributed among 0..TOP */
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  */
-    d__1 = (*top + 1.) * unif_(&c_b422);
+    d__1 = (*top + 1.) * unif_(&c_b424);
     ret_val = d_int(&d__1);
     return ret_val;
 } /* iran_ */
@@ -3688,7 +3716,7 @@ doublereal eran_(doublereal *top)
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  */
 L100:
-    u1 = unif_(&c_b422);
+    u1 = unif_(&c_b424);
     if (u1 <= 0.) {
 	goto L100;
     }
@@ -3716,7 +3744,7 @@ doublereal lran_(doublereal *top)
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  */
 L100:
-    u1 = unif_(&c_b422);
+    u1 = unif_(&c_b424);
     if (u1 <= 0. || u1 >= 1.) {
 	goto L100;
     }
@@ -3740,7 +3768,7 @@ doublereal uran_(doublereal *x)
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  */
 
-    ret_val = *x * unif_(&c_b422);
+    ret_val = *x * unif_(&c_b424);
     return ret_val;
 } /* uran_ */
 
@@ -3772,11 +3800,11 @@ doublereal gran2_(doublereal *b, doublereal *s)
 
     if (ip == 0) {
 L100:
-	u1 = unif_(&c_b422);
+	u1 = unif_(&c_b424);
 	if (u1 <= 0.) {
 	    goto L100;
 	}
-	u2 = unif_(&c_b422);
+	u2 = unif_(&c_b424);
 	ret_val = *b + *s * sqrt(log(u1) * -2.) * sin(u2 * 6.2831853);
 	ip = 1;
     } else {
@@ -3801,10 +3829,10 @@ doublereal gran1_(doublereal *b, doublereal *s)
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  */
 
-    g = unif_(&c_b436) - 6. + unif_(&c_b437) + unif_(&c_b438) + unif_(&c_b439)
-	     + unif_(&c_b440) + unif_(&c_b441) + unif_(&c_b442) + unif_(&
-	    c_b443) + unif_(&c_b444) + unif_(&c_b445) + unif_(&c_b446) + 
-	    unif_(&c_b447);
+    g = unif_(&c_b438) - 6. + unif_(&c_b439) + unif_(&c_b440) + unif_(&c_b441)
+	     + unif_(&c_b442) + unif_(&c_b443) + unif_(&c_b444) + unif_(&
+	    c_b445) + unif_(&c_b446) + unif_(&c_b447) + unif_(&c_b448) + 
+	    unif_(&c_b449);
     ret_val = *b + *s * g;
     return ret_val;
 } /* gran1_ */
@@ -3825,7 +3853,7 @@ doublereal gran_(doublereal *b, doublereal *s)
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  */
 
-    uu = unif_(&c_b422);
+    uu = unif_(&c_b424);
     if (uu <= .5) {
 	ret_val = gran1_(b, s);
     } else {

--- a/src/parser.c
+++ b/src/parser.c
@@ -9,40 +9,34 @@
 
 static integer c__3 = 3;
 static integer c__1 = 1;
-static doublereal c_b420 = 0.;
-static doublereal c_b434 = 1.;
-static doublereal c_b435 = 2.;
-static doublereal c_b436 = 3.;
-static doublereal c_b437 = 4.;
-static doublereal c_b438 = 5.;
-static doublereal c_b439 = 6.;
-static doublereal c_b440 = 7.;
-static doublereal c_b441 = 8.;
-static doublereal c_b442 = 9.;
-static doublereal c_b443 = 10.;
-static doublereal c_b444 = 11.;
-static doublereal c_b445 = 12.;
+static doublereal c_b422 = 0.;
+static doublereal c_b436 = 1.;
+static doublereal c_b437 = 2.;
+static doublereal c_b438 = 3.;
+static doublereal c_b439 = 4.;
+static doublereal c_b440 = 5.;
+static doublereal c_b441 = 6.;
+static doublereal c_b442 = 7.;
+static doublereal c_b443 = 8.;
+static doublereal c_b444 = 9.;
+static doublereal c_b445 = 10.;
+static doublereal c_b446 = 11.;
+static doublereal c_b447 = 12.;
 
-/* Subroutine */ int parser_(c_expr__, l_print__, num_code__, c_code__, 
-	c_expr_len, c_code_len)
-char *c_expr__;
-logical *l_print__;
-integer *num_code__;
-char *c_code__;
-ftnlen c_expr_len;
-ftnlen c_code_len;
+/* Subroutine */ int parser_(char *c_expr__, logical *l_print__, integer *
+	num_code__, char *c_code__, ftnlen c_expr_len, ftnlen c_code_len)
 {
     /* Initialized data */
 
-    static integer n_funcargs__[116] = { 1,1,1,1,1,1,2,1,1,1,1,1,1,1,1,1,1,1,
+    static integer n_funcargs__[118] = { 1,1,1,1,1,1,2,1,1,1,1,1,1,1,1,1,1,1,
 	    1,2,2,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,-1,-1,-1,2,1,1,1,
 	    -1,4,4,4,2,2,2,3,3,3,1,1,1,2,2,2,3,3,3,3,3,3,3,3,3,2,2,2,1,-1,-1,
 	    2,1,1,1,1,-1,1,-1,-1,-1,1,1,2,1,1,-1,-1,-1,2,5,5,-1,-1,-1,1,3,2,2,
-	    1,1,2,-1,-1,-1,-1,-1 };
+	    1,1,2,-1,-1,-1,-1,-1,-1,3 };
 
     /* Format strings */
-    static char fmt_9001[] = "(\002 PARSER error\002,i4,\002: \002,a/1x,a/80\
-a1)";
+    static char fmt_9001[] = "(\002 PARSER error\002,i4,\002: \002,a/1x,a/80"
+	    "a1)";
 
     /* System generated locals */
     address a__1[3];
@@ -50,20 +44,22 @@ a1)";
     static doublereal equiv_0[1];
 
     /* Builtin functions */
-    /* Subroutine */ int s_copy(), s_cat();
-    integer s_wsfe(), do_fio(), e_wsfe();
+    /* Subroutine */ int s_copy(char *, char *, ftnlen, ftnlen), s_cat(char *,
+	     char **, integer *, integer *, ftnlen);
+    integer s_wsfe(cilist *), do_fio(integer *, char *, ftnlen), e_wsfe(void);
 
     /* Local variables */
 #define r8_token__ (equiv_0)
     static integer narg, nlen, nerr, ipos, npos, nextcode, ncode;
     static char c_message__[30];
     static integer nfunc, nused;
-    extern /* Subroutine */ int get_token__();
+    extern /* Subroutine */ int get_token__(char *, integer *, doublereal *, 
+	    integer *, ftnlen);
     static doublereal val_token__;
-    extern integer last_nonblank__();
+    extern integer last_nonblank__(char *, ftnlen);
     static integer nf, n_code__[2048], n_func__[40], ntoken;
     static char c_local__[10000];
-    extern /* Subroutine */ int execute_();
+    extern /* Subroutine */ int execute_(integer *, char *, ftnlen);
 #define c8_token__ ((char *)equiv_0)
     static char c_ch__[1];
 
@@ -615,66 +611,80 @@ L9000:
 
 
 
-/* Subroutine */ int execute_(n_opcode__, c_code__, c_code_len)
-integer *n_opcode__;
-char *c_code__;
-ftnlen c_code_len;
+/* Subroutine */ int execute_(integer *n_opcode__, char *c_code__, ftnlen 
+	c_code_len)
 {
     /* Initialized data */
 
-    static char c_funcname__[32*117+1] = "SIN                             CO\
-S                             TAN                             ASIN          \
-                  ACOS                            ATAN                      \
-      ATAN2                           SINH                            COSH  \
-                          TANH                            ASINH             \
-              ACOSH                           ATANH                         \
-  EXP                             LOG                             LOG10     \
-                      ABS                             INT                   \
-          SQRT                            MAX                             MI\
-N                             AI                              DAI           \
-                  I0                              I1                        \
-      J0                              J1                              K0    \
-                          K1                              Y0                \
-              Y1                              BI                            \
-  DBI                             ERF                             ERFC      \
-                      GAMMA                           QG                    \
-          QGINV                           BELL2                           RE\
-CT                            STEP                            BOOL          \
-                  AND                             OR                        \
-      MOFN                            ASTEP                           SIND  \
-                          COSD                            TAND              \
-              MEDIAN                          FICO_T2P                      \
-  FICO_P2T                        FICO_T2Z                        FITT_T2P  \
-                      FITT_P2T                        FITT_T2Z              \
-          FIFT_T2P                        FIFT_P2T                        FI\
-FT_T2Z                        FIZT_T2P                        FIZT_P2T      \
-                  FIZT_T2Z                        FICT_T2P                  \
-      FICT_P2T                        FICT_T2Z                        FIBT_T\
-2P                        FIBT_P2T                        FIBT_T2Z          \
-              FIBN_T2P                        FIBN_P2T                      \
-  FIBN_T2Z                        FIGT_T2P                        FIGT_P2T  \
-                      FIGT_T2Z                        FIPT_T2P              \
-          FIPT_P2T                        FIPT_T2Z                        ZT\
-ONE                           LMODE                           HMODE         \
-                  GRAN                            URAN                      \
-      IRAN                            ERAN                            LRAN  \
-                          ORSTAT                          TENT              \
-              MAD                             ARGMAX                        \
-  ARGNUM                          NOTZERO                         ISZERO    \
-                      EQUALS                          ISPOSITIVE            \
-          ISNEGATIVE                      MEAN                            ST\
-DEV                           SEM                             PLEG          \
-                  CDF2STAT                        STAT2CDF                  \
-      PAIRMAX                         PAIRMIN                         AMONGS\
-T                         CBRT                            RHDDC2            \
-              HRFBK4                          HRFBK5                        \
-  POSVAL                          NOT                             MOD       \
-                      WITHIN                          MINABOVE              \
-          MAXBELOW                        EXTREME                         AB\
-SEXTREME                      DUMMY                           ";
+    static char c_funcname__[32*119] = "SIN                             " 
+	    "COS                             " "TAN                         "
+	    "    " "ASIN                            " "ACOS                  "
+	    "          " "ATAN                            " "ATAN2           "
+	    "                " "SINH                            " "COSH      "
+	    "                      " "TANH                            " "ASIN"
+	    "H                           " "ACOSH                           " 
+	    "ATANH                           " "EXP                         "
+	    "    " "LOG                             " "LOG10                 "
+	    "          " "ABS                             " "INT             "
+	    "                " "SQRT                            " "MAX       "
+	    "                      " "MIN                             " "AI  "
+	    "                            " "DAI                             " 
+	    "I0                              " "I1                          "
+	    "    " "J0                              " "J1                    "
+	    "          " "K0                              " "K1              "
+	    "                " "Y0                              " "Y1        "
+	    "                      " "BI                              " "DBI "
+	    "                            " "ERF                             " 
+	    "ERFC                            " "GAMMA                       "
+	    "    " "QG                              " "QGINV                 "
+	    "          " "BELL2                           " "RECT            "
+	    "                " "STEP                            " "BOOL      "
+	    "                      " "AND                             " "OR  "
+	    "                            " "MOFN                            " 
+	    "ASTEP                           " "SIND                        "
+	    "    " "COSD                            " "TAND                  "
+	    "          " "MEDIAN                          " "FICO_T2P        "
+	    "                " "FICO_P2T                        " "FICO_T2Z  "
+	    "                      " "FITT_T2P                        " "FITT"
+	    "_P2T                        " "FITT_T2Z                        " 
+	    "FIFT_T2P                        " "FIFT_P2T                    "
+	    "    " "FIFT_T2Z                        " "FIZT_T2P              "
+	    "          " "FIZT_P2T                        " "FIZT_T2Z        "
+	    "                " "FICT_T2P                        " "FICT_P2T  "
+	    "                      " "FICT_T2Z                        " "FIBT"
+	    "_T2P                        " "FIBT_P2T                        " 
+	    "FIBT_T2Z                        " "FIBN_T2P                    "
+	    "    " "FIBN_P2T                        " "FIBN_T2Z              "
+	    "          " "FIGT_T2P                        " "FIGT_P2T        "
+	    "                " "FIGT_T2Z                        " "FIPT_T2P  "
+	    "                      " "FIPT_P2T                        " "FIPT"
+	    "_T2Z                        " "ZTONE                           " 
+	    "LMODE                           " "HMODE                       "
+	    "    " "GRAN                            " "URAN                  "
+	    "          " "IRAN                            " "ERAN            "
+	    "                " "LRAN                            " "ORSTAT    "
+	    "                      " "TENT                            " "MAD "
+	    "                            " "ARGMAX                          " 
+	    "ARGNUM                          " "NOTZERO                     "
+	    "    " "ISZERO                          " "EQUALS                "
+	    "          " "ISPOSITIVE                      " "ISNEGATIVE      "
+	    "                " "MEAN                            " "STDEV     "
+	    "                      " "SEM                             " "PLEG"
+	    "                            " "CDF2STAT                        " 
+	    "STAT2CDF                        " "PAIRMAX                     "
+	    "    " "PAIRMIN                         " "AMONGST               "
+	    "          " "CBRT                            " "RHDDC2          "
+	    "                " "HRFBK4                          " "HRFBK5    "
+	    "                      " "POSVAL                          " "NOT "
+	    "                            " "MOD                             " 
+	    "WITHIN                          " "MINABOVE                    "
+	    "    " "MAXBELOW                        " "EXTREME               "
+	    "          " "ABSEXTREME                      " "CHOOSE          "
+	    "                " "IFELSE                          " "DUMMY     "
+	    "                      ";
 
     /* Builtin functions */
-    /* Subroutine */ int s_copy();
+    /* Subroutine */ int s_copy(char *, char *, ftnlen, ftnlen);
 
 
 /*  Execute the opcode on the evaluation stack.  Note that no attempt is 
@@ -761,65 +771,77 @@ L8000:
 
 
 
-/* Subroutine */ int get_token__(c_input__, ntype, value, nused, c_input_len)
-char *c_input__;
-integer *ntype;
-doublereal *value;
-integer *nused;
-ftnlen c_input_len;
+/* Subroutine */ int get_token__(char *c_input__, integer *ntype, doublereal *
+	value, integer *nused, ftnlen c_input_len)
 {
     /* Initialized data */
 
-    static char c_funcname__[32*117+1] = "SIN                             CO\
-S                             TAN                             ASIN          \
-                  ACOS                            ATAN                      \
-      ATAN2                           SINH                            COSH  \
-                          TANH                            ASINH             \
-              ACOSH                           ATANH                         \
-  EXP                             LOG                             LOG10     \
-                      ABS                             INT                   \
-          SQRT                            MAX                             MI\
-N                             AI                              DAI           \
-                  I0                              I1                        \
-      J0                              J1                              K0    \
-                          K1                              Y0                \
-              Y1                              BI                            \
-  DBI                             ERF                             ERFC      \
-                      GAMMA                           QG                    \
-          QGINV                           BELL2                           RE\
-CT                            STEP                            BOOL          \
-                  AND                             OR                        \
-      MOFN                            ASTEP                           SIND  \
-                          COSD                            TAND              \
-              MEDIAN                          FICO_T2P                      \
-  FICO_P2T                        FICO_T2Z                        FITT_T2P  \
-                      FITT_P2T                        FITT_T2Z              \
-          FIFT_T2P                        FIFT_P2T                        FI\
-FT_T2Z                        FIZT_T2P                        FIZT_P2T      \
-                  FIZT_T2Z                        FICT_T2P                  \
-      FICT_P2T                        FICT_T2Z                        FIBT_T\
-2P                        FIBT_P2T                        FIBT_T2Z          \
-              FIBN_T2P                        FIBN_P2T                      \
-  FIBN_T2Z                        FIGT_T2P                        FIGT_P2T  \
-                      FIGT_T2Z                        FIPT_T2P              \
-          FIPT_P2T                        FIPT_T2Z                        ZT\
-ONE                           LMODE                           HMODE         \
-                  GRAN                            URAN                      \
-      IRAN                            ERAN                            LRAN  \
-                          ORSTAT                          TENT              \
-              MAD                             ARGMAX                        \
-  ARGNUM                          NOTZERO                         ISZERO    \
-                      EQUALS                          ISPOSITIVE            \
-          ISNEGATIVE                      MEAN                            ST\
-DEV                           SEM                             PLEG          \
-                  CDF2STAT                        STAT2CDF                  \
-      PAIRMAX                         PAIRMIN                         AMONGS\
-T                         CBRT                            RHDDC2            \
-              HRFBK4                          HRFBK5                        \
-  POSVAL                          NOT                             MOD       \
-                      WITHIN                          MINABOVE              \
-          MAXBELOW                        EXTREME                         AB\
-SEXTREME                      DUMMY                           ";
+    static char c_funcname__[32*119] = "SIN                             " 
+	    "COS                             " "TAN                         "
+	    "    " "ASIN                            " "ACOS                  "
+	    "          " "ATAN                            " "ATAN2           "
+	    "                " "SINH                            " "COSH      "
+	    "                      " "TANH                            " "ASIN"
+	    "H                           " "ACOSH                           " 
+	    "ATANH                           " "EXP                         "
+	    "    " "LOG                             " "LOG10                 "
+	    "          " "ABS                             " "INT             "
+	    "                " "SQRT                            " "MAX       "
+	    "                      " "MIN                             " "AI  "
+	    "                            " "DAI                             " 
+	    "I0                              " "I1                          "
+	    "    " "J0                              " "J1                    "
+	    "          " "K0                              " "K1              "
+	    "                " "Y0                              " "Y1        "
+	    "                      " "BI                              " "DBI "
+	    "                            " "ERF                             " 
+	    "ERFC                            " "GAMMA                       "
+	    "    " "QG                              " "QGINV                 "
+	    "          " "BELL2                           " "RECT            "
+	    "                " "STEP                            " "BOOL      "
+	    "                      " "AND                             " "OR  "
+	    "                            " "MOFN                            " 
+	    "ASTEP                           " "SIND                        "
+	    "    " "COSD                            " "TAND                  "
+	    "          " "MEDIAN                          " "FICO_T2P        "
+	    "                " "FICO_P2T                        " "FICO_T2Z  "
+	    "                      " "FITT_T2P                        " "FITT"
+	    "_P2T                        " "FITT_T2Z                        " 
+	    "FIFT_T2P                        " "FIFT_P2T                    "
+	    "    " "FIFT_T2Z                        " "FIZT_T2P              "
+	    "          " "FIZT_P2T                        " "FIZT_T2Z        "
+	    "                " "FICT_T2P                        " "FICT_P2T  "
+	    "                      " "FICT_T2Z                        " "FIBT"
+	    "_T2P                        " "FIBT_P2T                        " 
+	    "FIBT_T2Z                        " "FIBN_T2P                    "
+	    "    " "FIBN_P2T                        " "FIBN_T2Z              "
+	    "          " "FIGT_T2P                        " "FIGT_P2T        "
+	    "                " "FIGT_T2Z                        " "FIPT_T2P  "
+	    "                      " "FIPT_P2T                        " "FIPT"
+	    "_T2Z                        " "ZTONE                           " 
+	    "LMODE                           " "HMODE                       "
+	    "    " "GRAN                            " "URAN                  "
+	    "          " "IRAN                            " "ERAN            "
+	    "                " "LRAN                            " "ORSTAT    "
+	    "                      " "TENT                            " "MAD "
+	    "                            " "ARGMAX                          " 
+	    "ARGNUM                          " "NOTZERO                     "
+	    "    " "ISZERO                          " "EQUALS                "
+	    "          " "ISPOSITIVE                      " "ISNEGATIVE      "
+	    "                " "MEAN                            " "STDEV     "
+	    "                      " "SEM                             " "PLEG"
+	    "                            " "CDF2STAT                        " 
+	    "STAT2CDF                        " "PAIRMAX                     "
+	    "    " "PAIRMIN                         " "AMONGST               "
+	    "          " "CBRT                            " "RHDDC2          "
+	    "                " "HRFBK4                          " "HRFBK5    "
+	    "                      " "POSVAL                          " "NOT "
+	    "                            " "MOD                             " 
+	    "WITHIN                          " "MINABOVE                    "
+	    "    " "MAXBELOW                        " "EXTREME               "
+	    "          " "ABSEXTREME                      " "CHOOSE          "
+	    "                " "IFELSE                          " "DUMMY     "
+	    "                      ";
 
     /* Format strings */
     static char fmt_5501[] = "(\002(F\002,i1,\002.0)\002)";
@@ -831,9 +853,10 @@ SEXTREME                      DUMMY                           ";
     static doublereal equiv_0[1];
 
     /* Builtin functions */
-    integer i_len(), s_cmp();
-    /* Subroutine */ int s_copy();
-    integer s_wsfi(), do_fio(), e_wsfi(), s_rsfi(), e_rsfi();
+    integer i_len(char *, ftnlen), s_cmp(char *, char *, ftnlen, ftnlen);
+    /* Subroutine */ int s_copy(char *, char *, ftnlen, ftnlen);
+    integer s_wsfi(icilist *), do_fio(integer *, char *, ftnlen), e_wsfi(void)
+	    , s_rsfi(icilist *), e_rsfi(void);
 
     /* Local variables */
     static integer nlen, ipos, npos;
@@ -974,7 +997,7 @@ L120:
 */
 
 	ifunc = 1;
-	s_copy(c_funcname__ + 3712, c_id__, 32L, 32L);
+	s_copy(c_funcname__ + 3776, c_id__, 32L, 32L);
 L210:
 	if (! (s_cmp(c_id__, c_funcname__ + (ifunc - 1 << 5), 32L, 32L) != 0))
 		 {
@@ -983,7 +1006,7 @@ L210:
 	++ifunc;
 	goto L210;
 L220:
-	if (ifunc <= 116) {
+	if (ifunc <= 118) {
 /* !it is a function */
 	    *ntype = 1008;
 	    *value = (doublereal) ifunc;
@@ -1127,15 +1150,13 @@ L8000:
 
 
 /* (((.................................................................... */
-integer last_nonblank__(cline, cline_len)
-char *cline;
-ftnlen cline_len;
+integer last_nonblank__(char *cline, ftnlen cline_len)
 {
     /* System generated locals */
     integer ret_val;
 
     /* Builtin functions */
-    integer i_len();
+    integer i_len(char *, ftnlen);
 
     /* Local variables */
     static integer npos;
@@ -1179,18 +1200,14 @@ L200:
 
 
 
-integer hassym_(sym, num_code__, c_code__, sym_len, c_code_len)
-char *sym;
-integer *num_code__;
-char *c_code__;
-ftnlen sym_len;
-ftnlen c_code_len;
+integer hassym_(char *sym, integer *num_code__, char *c_code__, ftnlen 
+	sym_len, ftnlen c_code_len)
 {
     /* System generated locals */
     integer ret_val, i__1;
 
     /* Builtin functions */
-    integer s_cmp();
+    integer s_cmp(char *, char *, ftnlen, ftnlen);
 
     /* Local variables */
     static integer ncode;
@@ -1229,53 +1246,87 @@ ftnlen c_code_len;
 
 
 
-doublereal pareval_(num_code__, c_code__, r8val, c_code_len)
-integer *num_code__;
-char *c_code__;
-doublereal *r8val;
-ftnlen c_code_len;
+doublereal pareval_(integer *num_code__, char *c_code__, doublereal *r8val, 
+	ftnlen c_code_len)
 {
     /* System generated locals */
     doublereal ret_val, d__1, d__2;
     static doublereal equiv_0[1];
 
     /* Builtin functions */
-    /* Subroutine */ int s_copy();
-    integer s_cmp();
-    double d_int(), pow_dd(), sin(), cos(), tan(), sqrt(), exp(), log(), 
-	    d_lg10(), asin(), acos(), atan(), atan2(), sinh(), cosh(), tanh();
+    /* Subroutine */ int s_copy(char *, char *, ftnlen, ftnlen);
+    integer s_cmp(char *, char *, ftnlen, ftnlen);
+    double d_int(doublereal *), pow_dd(doublereal *, doublereal *), sin(
+	    doublereal), cos(doublereal), tan(doublereal), sqrt(doublereal), 
+	    exp(doublereal), log(doublereal), d_lg10(doublereal *), asin(
+	    doublereal), acos(doublereal), atan(doublereal), atan2(doublereal,
+	     doublereal), sinh(doublereal), cosh(doublereal), tanh(doublereal)
+	    ;
 
     /* Local variables */
-    extern doublereal land_(), mean_(), derf_(), eran_(), gran_(), iran_(), 
-	    bool_(), lran_(), rect_(), legendre_(), uran_(), tent_(), step_(),
-	     minabove_(), maxbelow_(), bell2_(), derfc_();
+    extern doublereal land_(integer *, doublereal *), mean_(integer *, 
+	    doublereal *), derf_(doublereal *), eran_(doublereal *), gran_(
+	    doublereal *, doublereal *), iran_(doublereal *), bool_(
+	    doublereal *), lran_(doublereal *), rect_(doublereal *), 
+	    legendre_(doublereal *, doublereal *), uran_(doublereal *), tent_(
+	    doublereal *), step_(doublereal *), minabove_(integer *, 
+	    doublereal *), maxbelow_(integer *, doublereal *), bell2_(
+	    doublereal *), derfc_(doublereal *);
     static integer ncode;
     static doublereal x, y;
-    extern doublereal hmode_(), lmode_();
+    extern doublereal hmode_(integer *, doublereal *), lmode_(integer *, 
+	    doublereal *);
     static integer neval;
-    extern doublereal lmofn_(), qginv_(), stdev_(), ztone_(), zzmod_(), 
-	    dbesi0_(), dbesi1_(), dbesj0_(), dbesj1_(), dbesk0_(), dbesk1_();
+    extern doublereal lmofn_(integer *, integer *, doublereal *), qginv_(
+	    doublereal *), stdev_(integer *, doublereal *), ztone_(doublereal 
+	    *), zzmod_(doublereal *, doublereal *), dbesi0_(doublereal *), 
+	    dbesi1_(doublereal *), dbesj0_(doublereal *), dbesj1_(doublereal *
+	    ), dbesk0_(doublereal *), dbesk1_(doublereal *);
 #define c8_val__ ((char *)equiv_0)
-    extern doublereal rhddc2_(), hrfbk4_(), hrfbk5_(), cdf2st_(), dbesy0_(), 
-	    dbesy1_(), st2cdf_();
+    extern doublereal rhddc2_(doublereal *, doublereal *, doublereal *), 
+	    hrfbk4_(doublereal *, doublereal *), hrfbk5_(doublereal *, 
+	    doublereal *), cdf2st_(doublereal *, doublereal *, doublereal *, 
+	    doublereal *, doublereal *), dbesy0_(doublereal *), dbesy1_(
+	    doublereal *), st2cdf_(doublereal *, doublereal *, doublereal *, 
+	    doublereal *, doublereal *);
 #define r8_val__ (equiv_0)
-    extern doublereal dgamma_(), qg_();
+    extern doublereal dgamma_(doublereal *), qg_(doublereal *);
     static char cncode[8];
-    extern doublereal median_();
+    extern doublereal median_(integer *, doublereal *);
     static integer ialpha;
-    extern doublereal cbrtff_(), amongf_(), argmax_(), fibntp_(), fibnpt_(), 
-	    ficotp_(), ficopt_(), pairmn_(), fibttp_(), argnum_(), ficttp_(), 
-	    fictpt_(), fifttp_(), fiftpt_(), ficotz_(), fibtpt_(), pairmx_(), 
-	    fibntz_(), fibttz_(), ficttz_(), posval_(), figttp_(), fifttz_(), 
-	    figtpt_(), figttz_(), fitttp_(), fittpt_(), orstat_(), fipttp_(), 
-	    absextreme_(), fiptpt_(), fizttp_(), fiztpt_(), fipttz_(), 
-	    fitttz_(), fizttz_();
+    extern doublereal cbrtff_(doublereal *), amongf_(integer *, doublereal *),
+	     argmax_(integer *, doublereal *), choose_(integer *, integer *, 
+	    doublereal *), fibntp_(doublereal *, doublereal *, doublereal *), 
+	    fibnpt_(doublereal *, doublereal *, doublereal *), ficotp_(
+	    doublereal *, doublereal *, doublereal *, doublereal *), ficopt_(
+	    doublereal *, doublereal *, doublereal *, doublereal *), pairmn_(
+	    integer *, doublereal *), fibttp_(doublereal *, doublereal *, 
+	    doublereal *), argnum_(integer *, doublereal *), ficttp_(
+	    doublereal *, doublereal *), fictpt_(doublereal *, doublereal *), 
+	    fifttp_(doublereal *, doublereal *, doublereal *), fiftpt_(
+	    doublereal *, doublereal *, doublereal *), ficotz_(doublereal *, 
+	    doublereal *, doublereal *, doublereal *), fibtpt_(doublereal *, 
+	    doublereal *, doublereal *), pairmx_(integer *, doublereal *), 
+	    fibntz_(doublereal *, doublereal *, doublereal *), fibttz_(
+	    doublereal *, doublereal *, doublereal *), ficttz_(doublereal *, 
+	    doublereal *), posval_(doublereal *), figttp_(doublereal *, 
+	    doublereal *, doublereal *), fifttz_(doublereal *, doublereal *, 
+	    doublereal *), figtpt_(doublereal *, doublereal *, doublereal *), 
+	    figttz_(doublereal *, doublereal *, doublereal *), fitttp_(
+	    doublereal *, doublereal *), fittpt_(doublereal *, doublereal *), 
+	    orstat_(integer *, integer *, doublereal *), fipttp_(doublereal *,
+	     doublereal *), absextreme_(integer *, doublereal *), fiptpt_(
+	    doublereal *, doublereal *), fizttp_(doublereal *), fiztpt_(
+	    doublereal *), fipttz_(doublereal *, doublereal *), fitttz_(
+	    doublereal *, doublereal *), fizttz_(doublereal *);
     static doublereal r8_eval__[128];
-    extern doublereal dai_(), dbi_(), mad_(), sem_();
+    extern doublereal dai_(doublereal *), dbi_(doublereal *, integer *), mad_(
+	    integer *, doublereal *), sem_(integer *, doublereal *);
     static integer itm;
-    extern doublereal lor_();
+    extern doublereal lor_(integer *, doublereal *);
     static integer ntm;
-    extern doublereal withinf_(), extreme_();
+    extern doublereal withinf_(integer *, doublereal *), extreme_(integer *, 
+	    doublereal *);
 
 
 
@@ -1515,13 +1566,13 @@ L1000:
 /* ...................................................................
 .... */
     } else if (s_cmp(cncode, "SINH", 8L, 4L) == 0) {
-	if ((d__1 = r8_eval__[neval - 1], abs(d__1)) < (float)87.5) {
+	if ((d__1 = r8_eval__[neval - 1], abs(d__1)) < 87.5f) {
 	    r8_eval__[neval - 1] = sinh(r8_eval__[neval - 1]);
 	}
 /* ...................................................................
 .... */
     } else if (s_cmp(cncode, "COSH", 8L, 4L) == 0) {
-	if ((d__1 = r8_eval__[neval - 1], abs(d__1)) < (float)87.5) {
+	if ((d__1 = r8_eval__[neval - 1], abs(d__1)) < 87.5f) {
 	    r8_eval__[neval - 1] = cosh(r8_eval__[neval - 1]);
 	}
 /* ...................................................................
@@ -1757,6 +1808,19 @@ L1000:
 	ntm = (integer) r8_eval__[neval - 1];
 	neval -= ntm;
 	r8_eval__[neval - 1] = absextreme_(&ntm, &r8_eval__[neval - 1]);
+    } else if (s_cmp(cncode, "CHOOSE", 8L, 6L) == 0) {
+	ntm = (integer) r8_eval__[neval - 1];
+	neval -= ntm;
+	--ntm;
+	itm = (integer) r8_eval__[neval - 1];
+	r8_eval__[neval - 1] = choose_(&itm, &ntm, &r8_eval__[neval]);
+    } else if (s_cmp(cncode, "IFELSE", 8L, 6L) == 0) {
+	neval += -2;
+	if (r8_eval__[neval - 1] != 0.) {
+	    r8_eval__[neval - 1] = r8_eval__[neval];
+	} else {
+	    r8_eval__[neval - 1] = r8_eval__[neval + 1];
+	}
 /* ...................................................................
 .... */
     } else if (s_cmp(cncode, "FICO_T2P", 8L, 8L) == 0) {
@@ -1901,16 +1965,14 @@ L8000:
 
 
 
-/* Subroutine */ int parevec_(num_code__, c_code__, va, vb, vc, vd, ve, vf, 
-	vg, vh, vi, vj, vk, vl, vm, vn, vo, vp, vq, vr, vs, vt, vu, vv, vw, 
-	vx, vy, vz, lvec, vout, c_code_len)
-integer *num_code__;
-char *c_code__;
-doublereal *va, *vb, *vc, *vd, *ve, *vf, *vg, *vh, *vi, *vj, *vk, *vl, *vm, *
-	vn, *vo, *vp, *vq, *vr, *vs, *vt, *vu, *vv, *vw, *vx, *vy, *vz;
-integer *lvec;
-doublereal *vout;
-ftnlen c_code_len;
+/* Subroutine */ int parevec_(integer *num_code__, char *c_code__, doublereal 
+	*va, doublereal *vb, doublereal *vc, doublereal *vd, doublereal *ve, 
+	doublereal *vf, doublereal *vg, doublereal *vh, doublereal *vi, 
+	doublereal *vj, doublereal *vk, doublereal *vl, doublereal *vm, 
+	doublereal *vn, doublereal *vo, doublereal *vp, doublereal *vq, 
+	doublereal *vr, doublereal *vs, doublereal *vt, doublereal *vu, 
+	doublereal *vv, doublereal *vw, doublereal *vx, doublereal *vy, 
+	doublereal *vz, integer *lvec, doublereal *vout, ftnlen c_code_len)
 {
     /* System generated locals */
     integer i__1, i__2, i__3;
@@ -1918,54 +1980,88 @@ ftnlen c_code_len;
     static doublereal equiv_0[1];
 
     /* Builtin functions */
-    /* Subroutine */ int s_copy();
-    integer s_cmp();
-    double d_int(), pow_dd(), sin(), cos(), tan(), sqrt(), exp(), log(), 
-	    d_lg10(), asin(), acos(), atan(), atan2(), sinh(), cosh(), tanh();
+    /* Subroutine */ int s_copy(char *, char *, ftnlen, ftnlen);
+    integer s_cmp(char *, char *, ftnlen, ftnlen);
+    double d_int(doublereal *), pow_dd(doublereal *, doublereal *), sin(
+	    doublereal), cos(doublereal), tan(doublereal), sqrt(doublereal), 
+	    exp(doublereal), log(doublereal), d_lg10(doublereal *), asin(
+	    doublereal), acos(doublereal), atan(doublereal), atan2(doublereal,
+	     doublereal), sinh(doublereal), cosh(doublereal), tanh(doublereal)
+	    ;
 
     /* Local variables */
-    extern doublereal land_(), mean_(), derf_(), eran_(), gran_(), iran_(), 
-	    bool_(), lran_(), rect_();
+    extern doublereal land_(integer *, doublereal *), mean_(integer *, 
+	    doublereal *), derf_(doublereal *), eran_(doublereal *), gran_(
+	    doublereal *, doublereal *), iran_(doublereal *), bool_(
+	    doublereal *), lran_(doublereal *), rect_(doublereal *);
     static doublereal scop[101];
-    extern doublereal uran_(), legendre_(), tent_(), step_(), minabove_(), 
-	    maxbelow_(), bell2_();
+    extern doublereal uran_(doublereal *), legendre_(doublereal *, doublereal 
+	    *), tent_(doublereal *), step_(doublereal *), minabove_(integer *,
+	     doublereal *), maxbelow_(integer *, doublereal *), bell2_(
+	    doublereal *);
     static doublereal r8val[1664]	/* was [64][26] */;
-    extern doublereal derfc_();
+    extern doublereal derfc_(doublereal *);
     static integer ncode;
     static doublereal x, y;
-    extern doublereal hmode_(), lmode_();
+    extern doublereal hmode_(integer *, doublereal *), lmode_(integer *, 
+	    doublereal *);
     static integer neval;
-    extern doublereal lmofn_();
+    extern doublereal lmofn_(integer *, integer *, doublereal *);
     static integer ivbot;
-    extern doublereal qginv_(), stdev_();
+    extern doublereal qginv_(doublereal *), stdev_(integer *, doublereal *);
     static char c2code[8];
-    extern doublereal ztone_();
+    extern doublereal ztone_(doublereal *);
     static integer ivtop;
-    extern doublereal zzmod_(), dbesi0_(), dbesi1_(), dbesj0_(), dbesj1_(), 
-	    dbesk0_(), dbesk1_();
+    extern doublereal zzmod_(doublereal *, doublereal *), dbesi0_(doublereal *
+	    ), dbesi1_(doublereal *), dbesj0_(doublereal *), dbesj1_(
+	    doublereal *), dbesk0_(doublereal *), dbesk1_(doublereal *);
 #define c8_val__ ((char *)equiv_0)
-    extern doublereal rhddc2_(), hrfbk4_(), hrfbk5_(), cdf2st_(), dbesy0_(), 
-	    dbesy1_(), st2cdf_();
+    extern doublereal rhddc2_(doublereal *, doublereal *, doublereal *), 
+	    hrfbk4_(doublereal *, doublereal *), hrfbk5_(doublereal *, 
+	    doublereal *), cdf2st_(doublereal *, doublereal *, doublereal *, 
+	    doublereal *, doublereal *), dbesy0_(doublereal *), dbesy1_(
+	    doublereal *), st2cdf_(doublereal *, doublereal *, doublereal *, 
+	    doublereal *, doublereal *);
 #define r8_val__ (equiv_0)
     static integer jf;
-    extern doublereal dgamma_();
+    extern doublereal dgamma_(doublereal *);
     static integer ialpha, iv;
     static char cncode[8];
-    extern doublereal qg_(), median_(), argmax_(), pairmn_(), amongf_(), 
-	    argnum_(), ficotp_(), ficopt_(), fifttp_(), fiftpt_(), ficotz_(), 
-	    ficttp_(), pairmx_(), fictpt_(), fibttp_(), ficttz_(), posval_(), 
-	    fibtpt_(), fifttz_(), fibttz_(), fibntp_(), fitttp_(), fittpt_(), 
-	    orstat_(), fibnpt_(), absextreme_(), fibntz_(), fizttp_(), 
-	    fiztpt_(), figttp_(), figtpt_(), fitttz_(), figttz_(), fipttp_(), 
-	    fiptpt_(), fipttz_(), cbrtff_(), fizttz_();
+    extern doublereal qg_(doublereal *), median_(integer *, doublereal *), 
+	    argmax_(integer *, doublereal *), pairmn_(integer *, doublereal *)
+	    , amongf_(integer *, doublereal *), argnum_(integer *, doublereal 
+	    *), ficotp_(doublereal *, doublereal *, doublereal *, doublereal *
+	    ), ficopt_(doublereal *, doublereal *, doublereal *, doublereal *)
+	    , fifttp_(doublereal *, doublereal *, doublereal *), ficotz_(
+	    doublereal *, doublereal *, doublereal *, doublereal *), fiftpt_(
+	    doublereal *, doublereal *, doublereal *), pairmx_(integer *, 
+	    doublereal *), ficttp_(doublereal *, doublereal *), fictpt_(
+	    doublereal *, doublereal *), ficttz_(doublereal *, doublereal *), 
+	    posval_(doublereal *), fibttp_(doublereal *, doublereal *, 
+	    doublereal *), fifttz_(doublereal *, doublereal *, doublereal *), 
+	    fibtpt_(doublereal *, doublereal *, doublereal *), fibttz_(
+	    doublereal *, doublereal *, doublereal *), fitttp_(doublereal *, 
+	    doublereal *), fittpt_(doublereal *, doublereal *), orstat_(
+	    integer *, integer *, doublereal *), fibntp_(doublereal *, 
+	    doublereal *, doublereal *), absextreme_(integer *, doublereal *),
+	     fibnpt_(doublereal *, doublereal *, doublereal *), fizttp_(
+	    doublereal *), fiztpt_(doublereal *), fibntz_(doublereal *, 
+	    doublereal *, doublereal *), figttp_(doublereal *, doublereal *, 
+	    doublereal *), fitttz_(doublereal *, doublereal *), figtpt_(
+	    doublereal *, doublereal *, doublereal *), figttz_(doublereal *, 
+	    doublereal *, doublereal *), fipttp_(doublereal *, doublereal *), 
+	    fiptpt_(doublereal *, doublereal *), fipttz_(doublereal *, 
+	    doublereal *), fizttz_(doublereal *), cbrtff_(doublereal *);
     static doublereal r8_eval__[6464]	/* was [64][101] */;
-    extern doublereal dai_(), dbi_(), mad_();
+    extern doublereal dai_(doublereal *), dbi_(doublereal *, integer *), mad_(
+	    integer *, doublereal *);
     static integer ibv;
-    extern doublereal sem_();
+    extern doublereal sem_(integer *, doublereal *);
     static integer itm, jtm;
-    extern doublereal lor_();
+    extern doublereal lor_(integer *, doublereal *);
     static integer ntm;
-    extern doublereal withinf_(), extreme_();
+    extern doublereal withinf_(integer *, doublereal *), extreme_(integer *, 
+	    doublereal *);
 
 
 /*  Vector version of PAREVAL, where VA..VZ with length LVEC */
@@ -2420,8 +2516,7 @@ L1000:
 	    i__2 = ivtop;
 	    for (iv = ivbot; iv <= i__2; ++iv) {
 /* Computing MIN */
-		d__1 = (float)87.5, d__2 = r8_eval__[iv - ibv + (neval << 6) 
-			- 65];
+		d__1 = 87.5f, d__2 = r8_eval__[iv - ibv + (neval << 6) - 65];
 		r8_eval__[iv - ibv + (neval << 6) - 65] = exp((min(d__1,d__2))
 			);
 	    }
@@ -2619,7 +2714,7 @@ L1000:
 	    i__2 = ivtop;
 	    for (iv = ivbot; iv <= i__2; ++iv) {
 		if ((d__1 = r8_eval__[iv - ibv + (neval << 6) - 65], abs(d__1)
-			) < (float)87.5) {
+			) < 87.5f) {
 		    r8_eval__[iv - ibv + (neval << 6) - 65] = sinh(r8_eval__[
 			    iv - ibv + (neval << 6) - 65]);
 		}
@@ -2630,7 +2725,7 @@ L1000:
 	    i__2 = ivtop;
 	    for (iv = ivbot; iv <= i__2; ++iv) {
 		if ((d__1 = r8_eval__[iv - ibv + (neval << 6) - 65], abs(d__1)
-			) < (float)87.5) {
+			) < 87.5f) {
 		    r8_eval__[iv - ibv + (neval << 6) - 65] = cosh(r8_eval__[
 			    iv - ibv + (neval << 6) - 65]);
 		}
@@ -3458,14 +3553,13 @@ L8000:
 
 
 
-doublereal ztone_(x)
-doublereal *x;
+doublereal ztone_(doublereal *x)
 {
     /* System generated locals */
     doublereal ret_val;
 
     /* Builtin functions */
-    double tan(), tanh();
+    double tan(doublereal), tanh(doublereal);
 
     /* Local variables */
     static doublereal y;
@@ -3475,7 +3569,7 @@ doublereal *x;
 
     if (*x <= 0.) {
 	ret_val = 0.;
-    } else if (*x >= (float)1.) {
+    } else if (*x >= 1.f) {
 	ret_val = 1.;
     } else {
 	y = (*x * 1.6 - .8) * 1.5707963267948966;
@@ -3487,14 +3581,13 @@ doublereal *x;
 
 
 
-doublereal qg_(x)
-doublereal *x;
+doublereal qg_(doublereal *x)
 {
     /* System generated locals */
     doublereal ret_val, d__1;
 
     /* Local variables */
-    extern doublereal derfc_();
+    extern doublereal derfc_(doublereal *);
 
 
 /*  Compute the reversed cdf of a Gaussian. */
@@ -3555,23 +3648,22 @@ doublereal *x;
 
 
 
-doublereal iran_(top)
-doublereal *top;
+doublereal iran_(doublereal *top)
 {
     /* System generated locals */
     doublereal ret_val, d__1;
 
     /* Builtin functions */
-    double d_int();
+    double d_int(doublereal *);
 
     /* Local variables */
-    extern doublereal unif_();
+    extern doublereal unif_(doublereal *);
 
 
 /*  Return an integer uniformly distributed among 0..TOP */
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  */
-    d__1 = (*top + 1.) * unif_(&c_b420);
+    d__1 = (*top + 1.) * unif_(&c_b422);
     ret_val = d_int(&d__1);
     return ret_val;
 } /* iran_ */
@@ -3579,17 +3671,16 @@ doublereal *top;
 
 
 
-doublereal eran_(top)
-doublereal *top;
+doublereal eran_(doublereal *top)
 {
     /* System generated locals */
     doublereal ret_val;
 
     /* Builtin functions */
-    double log();
+    double log(doublereal);
 
     /* Local variables */
-    extern doublereal unif_();
+    extern doublereal unif_(doublereal *);
     static doublereal u1;
 
 
@@ -3597,7 +3688,7 @@ doublereal *top;
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  */
 L100:
-    u1 = unif_(&c_b420);
+    u1 = unif_(&c_b422);
     if (u1 <= 0.) {
 	goto L100;
     }
@@ -3608,17 +3699,16 @@ L100:
 
 
 
-doublereal lran_(top)
-doublereal *top;
+doublereal lran_(doublereal *top)
 {
     /* System generated locals */
     doublereal ret_val;
 
     /* Builtin functions */
-    double log();
+    double log(doublereal);
 
     /* Local variables */
-    extern doublereal unif_();
+    extern doublereal unif_(doublereal *);
     static doublereal u1;
 
 
@@ -3626,7 +3716,7 @@ doublereal *top;
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  */
 L100:
-    u1 = unif_(&c_b420);
+    u1 = unif_(&c_b422);
     if (u1 <= 0. || u1 >= 1.) {
 	goto L100;
     }
@@ -3637,29 +3727,27 @@ L100:
 
 
 
-doublereal uran_(x)
-doublereal *x;
+doublereal uran_(doublereal *x)
 {
     /* System generated locals */
     doublereal ret_val;
 
     /* Local variables */
-    extern doublereal unif_();
+    extern doublereal unif_(doublereal *);
 
 
 /*  Return a U(0,X) random variable. */
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  */
 
-    ret_val = *x * unif_(&c_b420);
+    ret_val = *x * unif_(&c_b422);
     return ret_val;
 } /* uran_ */
 
 
 
 
-doublereal gran2_(b, s)
-doublereal *b, *s;
+doublereal gran2_(doublereal *b, doublereal *s)
 {
     /* Initialized data */
 
@@ -3669,10 +3757,11 @@ doublereal *b, *s;
     doublereal ret_val;
 
     /* Builtin functions */
-    double log(), sqrt(), sin(), cos();
+    double log(doublereal), sqrt(doublereal), sin(doublereal), cos(doublereal)
+	    ;
 
     /* Local variables */
-    extern doublereal unif_();
+    extern doublereal unif_(doublereal *);
     static doublereal u1, u2;
 
 
@@ -3683,11 +3772,11 @@ doublereal *b, *s;
 
     if (ip == 0) {
 L100:
-	u1 = unif_(&c_b420);
+	u1 = unif_(&c_b422);
 	if (u1 <= 0.) {
 	    goto L100;
 	}
-	u2 = unif_(&c_b420);
+	u2 = unif_(&c_b422);
 	ret_val = *b + *s * sqrt(log(u1) * -2.) * sin(u2 * 6.2831853);
 	ip = 1;
     } else {
@@ -3700,23 +3789,22 @@ L100:
 
 
 
-doublereal gran1_(b, s)
-doublereal *b, *s;
+doublereal gran1_(doublereal *b, doublereal *s)
 {
     /* System generated locals */
     doublereal ret_val;
 
     /* Local variables */
-    extern doublereal unif_();
+    extern doublereal unif_(doublereal *);
     static doublereal g;
 
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  */
 
-    g = unif_(&c_b434) - 6. + unif_(&c_b435) + unif_(&c_b436) + unif_(&c_b437)
-	     + unif_(&c_b438) + unif_(&c_b439) + unif_(&c_b440) + unif_(&
-	    c_b441) + unif_(&c_b442) + unif_(&c_b443) + unif_(&c_b444) + 
-	    unif_(&c_b445);
+    g = unif_(&c_b436) - 6. + unif_(&c_b437) + unif_(&c_b438) + unif_(&c_b439)
+	     + unif_(&c_b440) + unif_(&c_b441) + unif_(&c_b442) + unif_(&
+	    c_b443) + unif_(&c_b444) + unif_(&c_b445) + unif_(&c_b446) + 
+	    unif_(&c_b447);
     ret_val = *b + *s * g;
     return ret_val;
 } /* gran1_ */
@@ -3724,20 +3812,20 @@ doublereal *b, *s;
 
 
 
-doublereal gran_(b, s)
-doublereal *b, *s;
+doublereal gran_(doublereal *b, doublereal *s)
 {
     /* System generated locals */
     doublereal ret_val;
 
     /* Local variables */
-    extern doublereal unif_(), gran1_(), gran2_();
+    extern doublereal unif_(doublereal *), gran1_(doublereal *, doublereal *),
+	     gran2_(doublereal *, doublereal *);
     static doublereal uu;
 
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  */
 
-    uu = unif_(&c_b420);
+    uu = unif_(&c_b422);
     if (uu <= .5) {
 	ret_val = gran1_(b, s);
     } else {
@@ -3749,14 +3837,13 @@ doublereal *b, *s;
 
 
 
-doublereal zzmod_(a, b)
-doublereal *a, *b;
+doublereal zzmod_(doublereal *a, doublereal *b)
 {
     /* System generated locals */
     doublereal ret_val, d__1;
 
     /* Builtin functions */
-    double d_int();
+    double d_int(doublereal *);
 
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  */
@@ -3773,18 +3860,17 @@ doublereal *a, *b;
 
 
 
-doublereal qginv_(p)
-doublereal *p;
+doublereal qginv_(doublereal *p)
 {
     /* System generated locals */
     doublereal ret_val, d__1;
 
     /* Builtin functions */
-    double log(), sqrt(), exp();
+    double log(doublereal), sqrt(doublereal), exp(doublereal);
 
     /* Local variables */
     static integer newt;
-    extern doublereal derfc_();
+    extern doublereal derfc_(doublereal *);
     static doublereal dp, dq, dt, dx, ddq;
 
 
@@ -3831,8 +3917,7 @@ L8000:
 
 
 
-doublereal bell2_(x)
-doublereal *x;
+doublereal bell2_(doublereal *x)
 {
     /* System generated locals */
     doublereal ret_val, d__1;
@@ -3857,8 +3942,7 @@ doublereal *x;
 
 
 
-doublereal rect_(x)
-doublereal *x;
+doublereal rect_(doublereal *x)
 {
     /* System generated locals */
     doublereal ret_val;
@@ -3878,8 +3962,7 @@ doublereal *x;
 
 
 
-doublereal step_(x)
-doublereal *x;
+doublereal step_(doublereal *x)
 {
     /* System generated locals */
     doublereal ret_val;
@@ -3895,8 +3978,7 @@ doublereal *x;
 
 
 
-doublereal posval_(x)
-doublereal *x;
+doublereal posval_(doublereal *x)
 {
     /* System generated locals */
     doublereal ret_val;
@@ -3912,8 +3994,7 @@ doublereal *x;
 
 
 
-doublereal tent_(x)
-doublereal *x;
+doublereal tent_(doublereal *x)
 {
     /* System generated locals */
     doublereal ret_val;
@@ -3933,8 +4014,7 @@ doublereal *x;
 
 
 
-doublereal bool_(x)
-doublereal *x;
+doublereal bool_(doublereal *x)
 {
     /* System generated locals */
     doublereal ret_val;
@@ -3950,9 +4030,7 @@ doublereal *x;
 
 
 
-doublereal land_(n, x)
-integer *n;
-doublereal *x;
+doublereal land_(integer *n, doublereal *x)
 {
     /* System generated locals */
     integer i__1;
@@ -3980,9 +4058,7 @@ doublereal *x;
 
 
 
-/* Subroutine */ int bsort_(n, x)
-integer *n;
-doublereal *x;
+/* Subroutine */ int bsort_(integer *n, doublereal *x)
 {
     /* System generated locals */
     integer i__1;
@@ -4017,16 +4093,14 @@ L50:
 
 
 
-doublereal orstat_(m, n, x)
-integer *m, *n;
-doublereal *x;
+doublereal orstat_(integer *m, integer *n, doublereal *x)
 {
     /* System generated locals */
     doublereal ret_val;
 
     /* Local variables */
     static integer i__;
-    extern /* Subroutine */ int bsort_();
+    extern /* Subroutine */ int bsort_(integer *, doublereal *);
 
 
     /* Parameter adjustments */
@@ -4052,9 +4126,7 @@ doublereal *x;
 
 
 
-doublereal pairmx_(n, x)
-integer *n;
-doublereal *x;
+doublereal pairmx_(integer *n, doublereal *x)
 {
     /* System generated locals */
     integer i__1;
@@ -4091,9 +4163,7 @@ doublereal *x;
 
 
 
-doublereal pairmn_(n, x)
-integer *n;
-doublereal *x;
+doublereal pairmn_(integer *n, doublereal *x)
 {
     /* System generated locals */
     integer i__1;
@@ -4130,9 +4200,7 @@ doublereal *x;
 
 
 
-doublereal amongf_(n, x)
-integer *n;
-doublereal *x;
+doublereal amongf_(integer *n, doublereal *x)
 {
     /* System generated locals */
     integer i__1;
@@ -4159,9 +4227,7 @@ doublereal *x;
 
 
 
-doublereal withinf_(n, x)
-integer *n;
-doublereal *x;
+doublereal withinf_(integer *n, doublereal *x)
 {
     /* System generated locals */
     doublereal ret_val;
@@ -4190,9 +4256,7 @@ doublereal *x;
 
 
 
-doublereal minabove_(n, x)
-integer *n;
-doublereal *x;
+doublereal minabove_(integer *n, doublereal *x)
 {
     /* System generated locals */
     integer i__1;
@@ -4233,9 +4297,7 @@ doublereal *x;
 
 
 
-doublereal maxbelow_(n, x)
-integer *n;
-doublereal *x;
+doublereal maxbelow_(integer *n, doublereal *x)
 {
     /* System generated locals */
     integer i__1;
@@ -4276,9 +4338,7 @@ doublereal *x;
 
 
 
-doublereal extreme_(n, x)
-integer *n;
-doublereal *x;
+doublereal extreme_(integer *n, doublereal *x)
 {
     /* System generated locals */
     integer i__1;
@@ -4302,14 +4362,14 @@ doublereal *x;
 	ret_val = aaa;
 	return ret_val;
     }
-    bbb = (float)0.;
+    bbb = 0.f;
     i__1 = *n;
     for (i__ = 1; i__ <= i__1; ++i__) {
 	if ((d__1 = x[i__], abs(d__1)) > bbb) {
 	    bbb = x[i__];
 	}
     }
-    if (bbb == (float)0.) {
+    if (bbb == 0.f) {
 	bbb = aaa;
     }
     ret_val = bbb;
@@ -4319,9 +4379,7 @@ doublereal *x;
 
 
 
-doublereal absextreme_(n, x)
-integer *n;
-doublereal *x;
+doublereal absextreme_(integer *n, doublereal *x)
 {
     /* System generated locals */
     integer i__1;
@@ -4345,14 +4403,14 @@ doublereal *x;
 	ret_val = aaa;
 	return ret_val;
     }
-    bbb = (float)0.;
+    bbb = 0.f;
     i__1 = *n;
     for (i__ = 1; i__ <= i__1; ++i__) {
 	if ((d__1 = x[i__], abs(d__1)) > bbb) {
 	    bbb = (d__2 = x[i__], abs(d__2));
 	}
     }
-    if (bbb == (float)0.) {
+    if (bbb == 0.f) {
 	bbb = aaa;
     }
     ret_val = bbb;
@@ -4362,9 +4420,28 @@ doublereal *x;
 
 
 
-doublereal mean_(n, x)
-integer *n;
-doublereal *x;
+doublereal choose_(integer *m, integer *n, doublereal *x)
+{
+    /* System generated locals */
+    doublereal ret_val;
+
+
+    /* Parameter adjustments */
+    --x;
+
+    /* Function Body */
+    if (*m < 1 || *n < *m) {
+	ret_val = 0.;
+	return ret_val;
+    }
+    ret_val = x[*m];
+    return ret_val;
+} /* choose_ */
+
+
+
+
+doublereal mean_(integer *n, doublereal *x)
 {
     /* System generated locals */
     integer i__1;
@@ -4398,16 +4475,14 @@ doublereal *x;
 
 
 
-doublereal stdev_(n, x)
-integer *n;
-doublereal *x;
+doublereal stdev_(integer *n, doublereal *x)
 {
     /* System generated locals */
     integer i__1;
     doublereal ret_val, d__1;
 
     /* Builtin functions */
-    double sqrt();
+    double sqrt(doublereal);
 
     /* Local variables */
     static doublereal xbar;
@@ -4443,18 +4518,16 @@ doublereal *x;
 
 
 
-doublereal sem_(n, x)
-integer *n;
-doublereal *x;
+doublereal sem_(integer *n, doublereal *x)
 {
     /* System generated locals */
     doublereal ret_val;
 
     /* Builtin functions */
-    double sqrt();
+    double sqrt(doublereal);
 
     /* Local variables */
-    extern doublereal stdev_();
+    extern doublereal stdev_(integer *, doublereal *);
 
 
     /* Parameter adjustments */
@@ -4468,15 +4541,13 @@ doublereal *x;
 
 
 
-doublereal median_(n, x)
-integer *n;
-doublereal *x;
+doublereal median_(integer *n, doublereal *x)
 {
     /* System generated locals */
     doublereal ret_val;
 
     /* Local variables */
-    extern /* Subroutine */ int bsort_();
+    extern /* Subroutine */ int bsort_(integer *, doublereal *);
     static integer it;
     static doublereal tmp;
 
@@ -4526,16 +4597,14 @@ doublereal *x;
 
 
 
-doublereal mad_(n, x)
-integer *n;
-doublereal *x;
+doublereal mad_(integer *n, doublereal *x)
 {
     /* System generated locals */
     integer i__1;
     doublereal ret_val, d__1;
 
     /* Local variables */
-    extern doublereal median_();
+    extern doublereal median_(integer *, doublereal *);
     static integer it;
     static doublereal tmp;
 
@@ -4565,9 +4634,7 @@ doublereal *x;
 
 
 
-doublereal argmax_(n, x)
-integer *n;
-doublereal *x;
+doublereal argmax_(integer *n, doublereal *x)
 {
     /* System generated locals */
     integer i__1;
@@ -4610,9 +4677,7 @@ doublereal *x;
 
 
 
-doublereal argnum_(n, x)
-integer *n;
-doublereal *x;
+doublereal argnum_(integer *n, doublereal *x)
 {
     /* System generated locals */
     integer i__1;
@@ -4641,9 +4706,7 @@ doublereal *x;
 
 
 
-doublereal hmode_(n, x)
-integer *n;
-doublereal *x;
+doublereal hmode_(integer *n, doublereal *x)
 {
     /* System generated locals */
     integer i__1;
@@ -4651,7 +4714,7 @@ doublereal *x;
 
     /* Local variables */
     static integer i__;
-    extern /* Subroutine */ int bsort_();
+    extern /* Subroutine */ int bsort_(integer *, doublereal *);
     static integer ib;
     static doublereal vb;
     static integer iv;
@@ -4696,9 +4759,7 @@ doublereal *x;
 
 
 
-doublereal lmode_(n, x)
-integer *n;
-doublereal *x;
+doublereal lmode_(integer *n, doublereal *x)
 {
     /* System generated locals */
     integer i__1;
@@ -4706,7 +4767,7 @@ doublereal *x;
 
     /* Local variables */
     static integer i__;
-    extern /* Subroutine */ int bsort_();
+    extern /* Subroutine */ int bsort_(integer *, doublereal *);
     static integer ib;
     static doublereal vb;
     static integer iv;
@@ -4751,9 +4812,7 @@ doublereal *x;
 
 
 
-doublereal lor_(n, x)
-integer *n;
-doublereal *x;
+doublereal lor_(integer *n, doublereal *x)
 {
     /* System generated locals */
     integer i__1;
@@ -4781,9 +4840,7 @@ doublereal *x;
 
 
 
-doublereal lmofn_(m, n, x)
-integer *m, *n;
-doublereal *x;
+doublereal lmofn_(integer *m, integer *n, doublereal *x)
 {
     /* System generated locals */
     integer i__1;
@@ -4815,29 +4872,26 @@ doublereal *x;
 
 
 
-doublereal dai_(x)
-doublereal *x;
+doublereal dai_(doublereal *x)
 {
     /* System generated locals */
     doublereal ret_val;
 
     /* Local variables */
-    extern /* Subroutine */ int qqqerr_();
+    extern /* Subroutine */ int qqqerr_(void);
 
     qqqerr_();
     ret_val = 0.;
     return ret_val;
 } /* dai_ */
 
-doublereal dbi_(x, i__)
-doublereal *x;
-integer *i__;
+doublereal dbi_(doublereal *x, integer *i__)
 {
     /* System generated locals */
     doublereal ret_val;
 
     /* Local variables */
-    extern /* Subroutine */ int qqqerr_();
+    extern /* Subroutine */ int qqqerr_(void);
 
     qqqerr_();
     ret_val = 0.;
@@ -4849,32 +4903,31 @@ integer *i__;
 /* cc      CALL QQQERR */
 /* cc      DGAMMA = 0.D+0 */
 /* cc      RETURN */
-/* Main program */ MAIN__()
+/* Main program */ MAIN__(void)
 {
+    return 0;
 } /* MAIN__ */
 
-doublereal dbesi0_(x)
-doublereal *x;
+doublereal dbesi0_(doublereal *x)
 {
     /* System generated locals */
     doublereal ret_val;
 
     /* Local variables */
-    extern /* Subroutine */ int qqqerr_();
+    extern /* Subroutine */ int qqqerr_(void);
 
     qqqerr_();
     ret_val = 0.;
     return ret_val;
 } /* dbesi0_ */
 
-doublereal dbesi1_(x)
-doublereal *x;
+doublereal dbesi1_(doublereal *x)
 {
     /* System generated locals */
     doublereal ret_val;
 
     /* Local variables */
-    extern /* Subroutine */ int qqqerr_();
+    extern /* Subroutine */ int qqqerr_(void);
 
     qqqerr_();
     ret_val = 0.;
@@ -4889,28 +4942,26 @@ doublereal *x;
 /* cc      REAL*8 X */
 /* cc      CALL QQQERR */
 /* cc      END */
-doublereal dbesk0_(x)
-doublereal *x;
+doublereal dbesk0_(doublereal *x)
 {
     /* System generated locals */
     doublereal ret_val;
 
     /* Local variables */
-    extern /* Subroutine */ int qqqerr_();
+    extern /* Subroutine */ int qqqerr_(void);
 
     qqqerr_();
     ret_val = 0.;
     return ret_val;
 } /* dbesk0_ */
 
-doublereal dbesk1_(x)
-doublereal *x;
+doublereal dbesk1_(doublereal *x)
 {
     /* System generated locals */
     doublereal ret_val;
 
     /* Local variables */
-    extern /* Subroutine */ int qqqerr_();
+    extern /* Subroutine */ int qqqerr_(void);
 
     qqqerr_();
     ret_val = 0.;
@@ -4934,14 +4985,14 @@ doublereal *x;
 /* cc      CALL QQQERR */
 /* cc      END */
 
-/* Subroutine */ int qqqerr_()
+/* Subroutine */ int qqqerr_(void)
 {
     /* Format strings */
     static char fmt_999[] = "(\002*** PARSER: unimplemented function ***\002)"
 	    ;
 
     /* Builtin functions */
-    integer s_wsfe(), e_wsfe();
+    integer s_wsfe(cilist *), e_wsfe(void);
 
     /* Fortran I/O blocks */
     static cilist io___144 = { 0, 6, 0, fmt_999, 0 };

--- a/src/parser.f
+++ b/src/parser.f
@@ -822,6 +822,7 @@ C
      X       MEAN , STDEV , SEM , POSVAL , ZZMOD
       REAL*8 ARGMAX,ARGNUM , PAIRMX,PAIRMN , AMONGF, WITHINF
       REAL*8 MINABOVE , MAXBELOW, EXTREME, ABSEXTREME
+      REAL*8 CHOOSE
 C
 C  External library functions
 C
@@ -1220,6 +1221,19 @@ C.......................................................................
             NTM   = R8_EVAL(NEVAL)
             NEVAL = NEVAL - NTM
             R8_EVAL(NEVAL) = ABSEXTREME( NTM , R8_EVAL(NEVAL) )
+         ELSEIF( CNCODE .EQ. 'CHOOSE'  )THEN
+            NTM   = R8_EVAL(NEVAL)
+            NEVAL = NEVAL - NTM
+            NTM   = NTM - 1
+            ITM   = R8_EVAL(NEVAL)
+            R8_EVAL(NEVAL) = CHOOSE( ITM,NTM , R8_EVAL(NEVAL+1) )
+         ELSEIF( CNCODE .EQ. 'IFELSE' )THEN
+            NEVAL = NEVAL - 2
+            IF( R8_EVAL(NEVAL) .NE. 0.D+0 )THEN
+                R8_EVAL(NEVAL) = R8_EVAL(NEVAL+1)
+            ELSE
+                R8_EVAL(NEVAL) = R8_EVAL(NEVAL+2)
+            ENDIF
 C.......................................................................
          ELSEIF( CNCODE .EQ. 'FICO_T2P' )THEN
             NEVAL = NEVAL - 3
@@ -1377,6 +1391,7 @@ C
      X       MEAN , STDEV , SEM , POSVAL , ZZMOD
       REAL*8 ARGMAX,ARGNUM , PAIRMX,PAIRMN, AMONGF, WITHINF
       REAL*8 MINABOVE , MAXBELOW, EXTREME, ABSEXTREME
+      REAL*8 CHOOSE
 C
 C  External library functions
 C
@@ -2953,6 +2968,20 @@ C
       ENDDO
       IF( BBB .EQ. 0.0 ) BBB = AAA
       ABSEXTREME = BBB
+      RETURN
+      END
+C
+C
+C
+      FUNCTION CHOOSE(M,N,X)
+      REAL*8  CHOOSE,X(N)
+      INTEGER M,N , I
+C
+      IF( M .LT. 1 .OR. N .LT. M)THEN
+         CHOOSE = 0.D+0
+         RETURN
+      ENDIF
+      CHOOSE = X(M)
       RETURN
       END
 C

--- a/src/parser.f
+++ b/src/parser.f
@@ -2223,6 +2223,26 @@ C.......................................................................
                ENDDO
                R8_EVAL(IV-IBV,NEVAL) = ABSEXTREME( NTM, SCOP )
             ENDDO
+         ELSEIF( CNCODE .EQ. 'CHOOSE' )THEN
+            NTM   = R8_EVAL(1, NEVAL)
+            NEVAL = NEVAL - NTM
+            NTM   = NTM - 1
+            DO IV=IVBOT,IVTOP
+               ITM = R8_EVAL(IV-IBV,NEVAL)
+               DO JTM=1,NTM
+                  SCOP(JTM) = R8_EVAL(IV-IBV,NEVAL+JTM)
+               ENDDO
+               R8_EVAL(IV-IBV,NEVAL) = CHOOSE( ITM, NTM, SCOP )
+            ENDDO
+         ELSEIF( CNCODE .EQ. 'IFELSE' )THEN
+            NEVAL = NEVAL - 2
+            DO IV=IVBOT,IVTOP
+               IF( R8_EVAL(IV-IBV,NEVAL) .NE. 0.D+0 )THEN
+                  R8_EVAL(IV-IBV,NEVAL) = R8_EVAL(IV-IBV,NEVAL+1)
+               ELSE
+                  R8_EVAL(IV-IBV,NEVAL) = R8_EVAL(IV-IBV,NEVAL+2)
+               ENDIF
+            ENDDO
 
 
 C.......................................................................

--- a/src/parser.h
+++ b/src/parser.h
@@ -109,7 +109,7 @@ extern "C" {                    /* care of Greg Balls    7 Aug 2006 [rickr] */
   "    sind , cosd , tand , median, lmode , hmode , mad  ,       \n"           \
   "    gran , uran , iran , eran  , lran  , orstat, mod  ,       \n"           \
   "    mean , stdev, sem  , Pleg  , cbrt  , rhddc2, hrfbk4,hrfbk5\n"           \
-  "    minbelow, maxabove\n"                                                   \
+  "    minbelow, maxabove, extreme, absextreme\n"                              \
   "\n"                                                                         \
   " where some of the less obvious funcions are:\n"                            \
   " * qg(x)    = reversed cdf of a standard normal distribution\n"             \
@@ -141,7 +141,7 @@ extern "C" {                    /* care of Greg Balls    7 Aug 2006 [rickr] */
   "    of their arguments - lmode breaks ties by choosing the\n"               \
   "    smallest value with the maximal count, hmode breaks ties by\n"          \
   "    choosing the largest value with the maximal count\n"                    \
-  "    [median,lmode,hmode take a variable number of arguments]\n"             \
+  "    [\"a,b,c,...\" indicates a variable number of arguments]\n"             \
   " * gran(m,s) returns a Gaussian deviate with mean=m, stdev=s\n"             \
   " * uran(r)   returns a uniform deviate in the range [0,r]\n"                \
   " * iran(t)   returns a random integer in the range [0..t]\n"                \
@@ -176,9 +176,10 @@ extern "C" {                    /* care of Greg Balls    7 Aug 2006 [rickr] */
   "     equals(x,y)  = 1-bool(x-y) = { 1 if x == y , 0 if x != y },\n"         \
   "   ispositive(x)  = { 1 if x > 0; 0 if x <= 0 },\n"                         \
   "   isnegative(x)  = { 1 if x < 0; 0 if x >= 0 },\n"                         \
+  "   ifelse(x,t,f)  = { t if x != 0; f if x == 0 },\n"                        \
+  "        not(x)    = same as iszero(x) = Boolean negation\n"                 \
   "   and(a,b,...,c) = {1 if all arguments are nonzero, 0 if any are zero}\n"  \
   "    or(a,b,...,c) = {1 if any arguments are nonzero, 0 if all are zero}\n"  \
-  "        not(x)    = same as iszero(x) = Boolean negation\n"                 \
   "  mofn(m,a,...,c) = {1 if at least 'm' arguments are nonzero, else 0 }\n"   \
   "  argmax(a,b,...) = index of largest argument; = 0 if all args are 0\n"     \
   "  argnum(a,b,...) = number of nonzero arguments\n"                          \
@@ -194,8 +195,10 @@ extern "C" {                    /* care of Greg Balls    7 Aug 2006 [rickr] */
   "                    (The 'pair' functions are Lukas Pezawas specials!)\n"   \
   "  amongst(a,b,...)= Return value is 1 if any of the b,c,... values\n"       \
   "                    equals the a value; otherwise, return value is 0.\n"    \
+  " choose(n,a,b,...)= chooses the n-th value from the a,b,... values.\n"      \
+  "                    (e.g., choose(2,a,b,c) is b)\n"                         \
   "\n"                                                                         \
-  "  [These last 8 functions take a variable number of arguments.]\n"          \
+  "  [These last 9 functions take a variable number of arguments.]\n"          \
   "\n"                                                                         \
   " The following 27 functions are used for statistical conversions,\n"        \
   " as in the program 'cdf':\n"                                                \

--- a/src/parser.inc
+++ b/src/parser.inc
@@ -45,7 +45,7 @@ C.......................................................................
 C  Define Function names, etc.
 C
       INTEGER     NUM_FUNC
-      PARAMETER ( NUM_FUNC = 116 )
+      PARAMETER ( NUM_FUNC = 118 )
 C
       CHARACTER*32 C_FUNCNAME(NUM_FUNC+1)
       INTEGER      N_FUNCARGS(NUM_FUNC)
@@ -85,7 +85,9 @@ C
      X
      X 'HRFBK4'  , 'HRFBK5' , 'POSVAL' , 'NOT' , 'MOD' , 'WITHIN',
      X
-     X 'MINABOVE' , 'MAXBELOW' ,"EXTREME", "ABSEXTREME",
+     X 'MINABOVE' , 'MAXBELOW' ,'EXTREME', 'ABSEXTREME',
+     X
+     X 'CHOOSE', 'IFELSE',
      X
      X 'DUMMY' /
 C
@@ -93,5 +95,5 @@ C
      X                 3*4, 3*2, 3*3, 3*1, 3*2, 3*3, 3*3, 3*3, 3*2 ,
      X   1 , -1,-1 , 2 , 1 , 1 , 1 , 1 , -1 ,1 , -1  ,
      X  -1,-1, 1,1,2,1,1, -1,-1,-1, 2, 5,5, -1,-1,-1,1,3, 2,2,1,1,2,
-     X  -1, -1,-1, -1, -1 /
+     X  -1, -1,-1, -1, -1, -1, 3 /
 C-----------------------------------------------------------------------


### PR DESCRIPTION
I've been wanting these functions for a while now, and I finally got around to doing something about it.

- `choose(n,a,b,c,...)` chooses the n-th element of a,b,c,...
    (e.g., `choose(2,a,b,c)` is `b`)
- `ifelse(p,t,f)` is equivalent to `p ? t : f`

I basically just copied the changes in a02241d7c4c9ac318b736db8b4d93e1123992109 and tweaked.

This change has been tested some and seems to work, but it should still be looked over by someone who knew Fortran this morning. Also regenerating `parser.c` might be necessary.

```bash
$ ./ccalc 'ifelse(0,1,2)'
2.000000
$ ./ccalc 'ifelse(1,1,2)'
1.000000
$ ./ccalc 'ifelse(7.5,1,2)'
1.000000
$ ./ccalc 'ifelse(0,1,2,3)'
 PARSER error  12: Wrong number of arguments     
 IFELSE(0,1,2,3) 
.............#
parser error!
$ ./ccalc 'ifelse(0,1)'
 PARSER error  12: Wrong number of arguments     
 IFELSE(0,1) 
...........#
parser error!
# If n < 1, error so return 0
$ ./ccalc 'choose(0)'
0.000000
# If not enough args, error so return 0
$ ./ccalc 'choose(1)'
0.000000
$ ./ccalc 'choose(-.3,1,2,3,4,5,6)'
0.000000
$ ./ccalc 'choose(1,1,2,3,4,5,6)'
1.000000
$ ./ccalc 'choose(5,1,2,3,4,5,6)'
5.000000
$ ./ccalc 'choose(5,10,20,30,40,50,60)'
50.000000
$ ./ccalc 'choose(7,10,20,30,40,50,60)'
0.000000
# Round down
$ ./ccalc 'choose(4.9,10,20,30,40,50,60)'
40.000000
```