### PR TITLE
Add check for any attempt to append data after the cdata element was closed.

### DIFF
--- a/src/gifti/gifti_xml.c
+++ b/src/gifti/gifti_xml.c
@@ -1610,7 +1610,12 @@ static void XMLCALL cb_char(void *udata, const char * cdata, int length)
         case GXML_ETYPE_XFORMSPACE :
             if( xd->verb > 4 )
                 fprintf(stderr,"++ append cdata, parent %s\n",enames[parent]);
-            (void)append_to_cdata(xd, cdata, length);
+            if( xd->cdata == NULL ) {
+                if ( xd->verb > 4 )
+                    fprintf(stderr, "   excess data.\n");
+            }
+            else
+                (void)append_to_cdata(xd, cdata, length);
             break;
 
         case GXML_ETYPE_CDATA      :


### PR DESCRIPTION
[Resubmitting on other repo]

I noticed that any whitespace after a CDATA item in the metadata of a GIFTI file causes a segfault. Adding an extra check here allows the library to parse what appear to be legal GIFTI files. See for example the file RY_TAL_RH_RECOSM.surf.gii in the archive:

http://www.nitrc.org/frs/download.php/377/SurfaceInBrainVoyagerAndGIfTI.zip

Before applying this fix, gifti_tool will crash reading this file. Afterwards, it complains about the version number, but otherwise parses the file correctly.

I hope this is useful.