### PR TITLE
BF(workaround): export PS4=+ within XmHTML Makefile

### DIFF
--- a/src/XmHTML/Makefile
+++ b/src/XmHTML/Makefile
@@ -180,6 +180,9 @@ LOADLIBES = $(LIBDIR) $(LIBS) $(IMAGELIBS)
 
 ### End of User configurable section ###
 
+# To guarantee robust "set -x" operation
+export PS4=+
+
 pass_flags = SHELL='$(SHELL)' \
 	VERSION='$(VERSION)' \
 	CC='$(CC)' \

--- a/src/XmHTML/lib/Makefile
+++ b/src/XmHTML/lib/Makefile
@@ -33,6 +33,9 @@ TARGET=$(LIBRARY)
 # Subdirectories to visit
 SUBDIRS= common $(PLATFORM)
 
+# To guarantee robust "set -x" operation
+export PS4=+
+
 # Target rules
 all:: $(TARGET)
 


### PR DESCRIPTION
to workaround the side-effect of users setting up too fancy for dash to
handle PS4 prompts, leading to obscure failures

Closes: #31 