### PR TITLE
call glutInit in SUMA_STANDALONE_INIT

### DIFF
--- a/src/SUMA/SUMA_DataSets.h
+++ b/src/SUMA/SUMA_DataSets.h
@@ -21,6 +21,7 @@
 	      }  \
          /* SUMAg_CF->scm = SUMA_Build_Color_maps();  require X connection*/\
       SUMA_ParseInput_basics_s (argv, argc);   \
+      glutInit(& argc, argv); \
    }
 #endif   
 


### PR DESCRIPTION
Otherwise suma would crash with

  freeglut  ERROR:  Function <glutBitmapWidth> called without first calling 'glutInit'.

upon right click on a mesh

Originally written: 2012-11-29
