### PR TITLE
Matlab: minor refactoring and fix in setting call stack in NIML history

### DIFF
--- a/src/matlab/afni_niml_writesimple.m
+++ b/src/matlab/afni_niml_writesimple.m
@@ -91,7 +91,8 @@ if size(idxs,1)==1
 end
 
 if numel(idxs) ~= nverts
-    error('The number of node indices (%d) does not match the number of rows (%d) in the data.',nverts,numel(idxs));
+    error(['The number of node indices (%d) does not match the '...
+                'number of rows (%d) in the data.'],nverts,numel(idxs));
 end
 
 nd.data=idxs;
@@ -116,19 +117,24 @@ end
 
 % default value for history; make call stack
 st=dbstack();
-stc=cell(numel(st));
+stc=cell(numel(st),1);
 for j=1:numel(st)
     stc{j}=sprintf('%s (%d)',st(j).name,st(j).line);
 end
-defaulthistory=sprintf('Written %s using: %s',datestr(clock),unsplit_string(stc,' <- '));
+defaulthistory=sprintf('Written %s using: %s',datestr(clock),...
+                                unsplit_string(stc,' <- '));
 if isfield(S,'history')
     S.history=[S.history ';' defaulthistory];
 end
 
-nodes{4}=make_str_element('COLMS_LABS',S,'labels',defaultlabels,ncols);
-nodes{5}=make_str_element('COLMS_TYPE',S,'types',make_default_type(S.data),ncols); % as of May 2011, use make_default_type; see below
-nodes{6}=make_str_element('COLMS_STATSYM',S,'stats',{'none'},ncols);
-nodes{7}=make_str_element('HISTORY_NOTE',S,'history',defaulthistory,ncols);
+nodes{4}=make_str_element('COLMS_LABS',S,'labels',...
+                        defaultlabels,ncols);
+nodes{5}=make_str_element('COLMS_TYPE',S,'types',...
+                        make_default_type(S.data),ncols);
+nodes{6}=make_str_element('COLMS_STATSYM',S,'stats',...
+                        {'none'},ncols);
+nodes{7}=make_str_element('HISTORY_NOTE',S,'history',...
+                        defaulthistory,ncols);
 
 D.nodes=nodes;
 
@@ -169,7 +175,8 @@ if iscell(vals);
     end
     vals=unsplit_string(v,';');
 elseif ~ischar(vals)
-    error('Unrecognized data type for field %s (%s)', Nodefieldname, Sfieldname);
+    error('Unrecognized data type for field %s (%s)', ...
+                                Nodefieldname, Sfieldname);
 end
 
 elem.data={{vals}};

--- a/src/matlab/unsplit_string.m
+++ b/src/matlab/unsplit_string.m
@@ -9,8 +9,8 @@ function s=unsplit_string(c, sep)
 %
 % NNO Jan 2010
 
-if ~iscell(c)
-    error('Expected cell input');
+if ~iscellstr(c)
+    error('Expected cell string input');
 end
 
 n=numel(c);
@@ -19,14 +19,14 @@ if n==0
     return
 end
 
-r=cell(1,2*n);
+% insert separator string
+parts=cell(1,2*n-1);
 for k=1:n
-    r{k*2-1}=sep;
-    r{k*2}=c{k};
+    parts{k*2-1}=c{k};
+    if k>1
+        parts{k}=sep;
+    end
 end
 
-s=[r{2:end}];
-
-
-
-
+% concatenate
+s=sprintf('%s',parts{:});


### PR DESCRIPTION
Minor changes in some of the Matlab code involved in writing NIML files. Fixes string formatting appended to NIML file history contents.