### PR TITLE
removed -V option from CCOLD line

### DIFF
--- a/src/Makefile.linux_openmp
+++ b/src/Makefile.linux_openmp
@@ -47,7 +47,7 @@ CEXTRA = -Wcomment -Wformat -DUSE_TRACING -DHAVE_XDBE $(CPROF) -DDONT_USE_XTDEST
 CC     = /usr/bin/gcc -O2 -m32 -fPIC -DREAD_WRITE_64 -DLINUX2 $(CEXTRA)
 CCVOL  = /usr/bin/gcc -O2 -m32 -fPIC -DLINUX2 $(CEXTRA)
 CCFAST = /usr/bin/gcc -O2 -m32 -fPIC -DLINUX2 $(CEXTRA)
-CCOLD  = /usr/bin/gcc -V 34 -O2 -m32 -fPIC -ffast-math -mmmx -DREAD_WRITE_64 -DLINUX2 $(CEXTRA)
+CCOLD  = /usr/bin/gcc -O2 -m32 -fPIC -ffast-math -mmmx -DREAD_WRITE_64 -DLINUX2 $(CEXTRA)
 
 # The following line includes compiling for the SSE operations.
 # However, I found that it actually makes things worse in some test code.

--- a/src/Makefile.linux_openmp_64
+++ b/src/Makefile.linux_openmp_64
@@ -46,7 +46,7 @@ CEXTRA = -Wcomment -Wformat -DUSE_TRACING -DHAVE_XDBE $(CPROF) -DDONT_USE_XTDEST
 CC     = /usr/bin/gcc -O2 -m64 -fPIC -DREAD_WRITE_64 -DLINUX2 $(CEXTRA)
 CCVOL  = /usr/bin/gcc -O2 -m64 -fPIC -DREAD_WRITE_64 -DLINUX2 $(CEXTRA)
 CCFAST = /usr/bin/gcc -O2 -m64 -fPIC -DREAD_WRITE_64 -DLINUX2 $(CEXTRA)
-CCOLD  = /usr/bin/gcc -V 34 -O2 -m64 -fPIC -DREAD_WRITE_64 -DLINUX2 $(CEXTRA)
+CCOLD  = /usr/bin/gcc -O2 -m64 -fPIC -DREAD_WRITE_64 -DLINUX2 $(CEXTRA)
 
 # The following line includes compiling for the SSE operations.
 # However, I found that it actually makes things worse in some test code.


### PR DESCRIPTION
The build failed at nifti/nifticdf/nifticdf.c because gcc was given the
-V option