### PR TITLE
Travis: set PATH variable so that afni binaries precede other binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ script:
     - export PATH=$PATH:$PWD/$FLAVOR  # to gain access to built binaries
     - mkdir ../testing; cd ../testing # from here will run tests
     - cmake -DAFNI_BUILD_TESTS:BOOL=ON ..
-    - ctest
+    - ctest --verbose
     # Smoke tests for some additional commands
     - 3dinfo

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - FLAVOR=linux_ubuntu_12_64
 before_install:
     # install build-dependencies as the doc says
-    - sudo sh src/other_builds/OS_notes.linux_ubuntu_12_64
+    - sudo sh src/other_builds/OS_notes.$FLAVOR
     # install packages needed for testing
     - sudo apt-get install xvfb xauth libgl1-mesa-dri mesa-utils tcsh libjpeg-progs
 install:
@@ -15,7 +15,9 @@ install:
     - cp other_builds/Makefile.$FLAVOR Makefile
     - make vastness
 script:
-    - export PATH=$PATH:$PWD/$FLAVOR  # to gain access to built binaries
+    # to gain access to built binaries, include path first
+    # (otherwise the wrong `count` binary may be used in the tests)
+    - export PATH=$PWD/$FLAVOR:$PATH
     - mkdir ../testing; cd ../testing # from here will run tests
     - cmake -DAFNI_BUILD_TESTS:BOOL=ON ..
     - ctest --verbose


### PR DESCRIPTION
This addresses failing travis tests due to using the wrong `count` program.

Addresses #56; see also AFNI message board discussion at https://afni.nimh.nih.gov/afni/community/board/read.php?1,155735,155735#msg-155735

Thanks to @yarikoptic for PR #57.