### PR TITLE
FIX: correct issue in AFNI Matlab library "unsplit_string" function

### DIFF
--- a/src/matlab/unsplit_string.m
+++ b/src/matlab/unsplit_string.m
@@ -23,8 +23,8 @@ end
 parts=cell(1,2*n-1);
 for k=1:n
     parts{k*2-1}=c{k};
-    if k>1
-        parts{k}=sep;
+    if k<n
+        parts{k*2}=sep;
     end
 end
 


### PR DESCRIPTION
Minor fix in the AFNI Matlab library.

``unsplit_string`` produces incorrect results if more than two strings are "unsplit". This results in incorrect NIML files being written.

ping @afni-rickr @afni-gangc 