### PR TITLE
fix for -despike_mask option in afni_proc.py?

### DIFF
--- a/src/python_scripts/db_mod.py
+++ b/src/python_scripts/db_mod.py
@@ -1067,7 +1067,7 @@ def db_cmd_despike(proc, block):
     prev   = proc.prev_prefix_form_run(block, view=1)
 
     # maybe the user wants to mask here (to speed this step up)
-    if block.opts.find_opt('-despike_opts_mask'): mstr = ''
+    if block.opts.find_opt('-despike_mask'): mstr = ''
     else:                                         mstr = ' -nomask'
 
     # default to 3dDespike -NEW for now


### PR DESCRIPTION
Hello! 

The `-despike_mask` option flag to afni_proc.py seems to have no effect. 

Investigating this issue is the first time I've looked at the afni source, so this proposed change might be totally off the mark, but I think it addresses the problem. `-despike_mask` works as expected on my machine after making it, at least. 