### PR TITLE
Fix implicit function declarations warnings

### DIFF
--- a/src/3DEdge/src/extrema.c
+++ b/src/3DEdge/src/extrema.c
@@ -20,6 +20,7 @@
  */
 
 #include <extrema.h>
+#include <convert.h>
 
 static int _VERBOSE_ = 0;
 

--- a/src/3dAFNItoNIML.c
+++ b/src/3dAFNItoNIML.c
@@ -31,7 +31,12 @@ int main( int argc , char *argv[] )
    }
 
    mainENTRY("3dAFNItoNIML main"); machdep(); PRINT_VERSION("3dAFNItoNIML");
-   if( PRINT_TRACING ){ STATUS("Enable mcw_malloc()"); enable_mcw_malloc(); }
+   if( PRINT_TRACING ){
+     STATUS("Enable mcw_malloc()");
+#ifndef DONT_USE_MCW_MALLOC
+     enable_mcw_malloc();
+#endif
+   }
 
    /*-- read command line options --*/
 

--- a/src/3dTproject.c
+++ b/src/3dTproject.c
@@ -663,7 +663,7 @@ STATUS("making list of keepers") ;
    keep = (int *)malloc( sizeof(int) * ntkeep ) ;
    for( qq=jj=0 ; jj < nt ; jj++ ) if( tp->censar[jj] != 0.0f ) keep[qq++] = jj ;
 
-   (void)mcw_malloc_status("3dTproject.c",__LINE__) ;
+   MCW_MALLOC_status ;
 
    INFO_message("Setting up regressors") ;
 
@@ -734,7 +734,7 @@ fprintf(stderr,"\n") ;
 #endif
      }
 
-     (void)mcw_malloc_status("3dTproject.c",__LINE__) ;
+     MCW_MALLOC_status ;
 
      if( nort_fixed >= nt ){
        ERROR_message(
@@ -884,7 +884,7 @@ STATUS("loading polort vectors") ;
            opp[jj] = Plegendre( fac*(jj-bla[tt])-1.0 , pp ) ;
        }
      }
-     (void)mcw_malloc_status("3dTproject.c",__LINE__) ;
+     MCW_MALLOC_status ;
    }
 
    /*-- load cosine/sine (stopbands) part of ort_fixed_unc --*/
@@ -910,7 +910,7 @@ STATUSi("sin qort",qort) ;
      }
      free(fmask) ; free(nf) ; free(df) ;
      fmask = NULL ; nf = NULL ; df = NULL ;
-     (void)mcw_malloc_status("3dTproject.c",__LINE__) ;
+     MCW_MALLOC_status ;
    }
 
    /*-- load ortar part of ort_fixed_unc --*/
@@ -927,7 +927,7 @@ STATUS("loading ortar") ;
          vector_demean( nt , opp ) ;
        }
      }
-     (void)mcw_malloc_status("3dTproject.c",__LINE__) ;
+     MCW_MALLOC_status ;
    }
 
    /*---- censor ort_fixed_unc into ort_fixed ----*/
@@ -955,7 +955,7 @@ STATUS("censoring orts") ;
      if( nort_fixed == 0 )
        ERROR_exit("Censoring results in no nonzero fixed orts!") ;
      free(ort_fixed_unc) ; ort_fixed_unc = NULL ;
-     (void)mcw_malloc_status("3dTproject.c",__LINE__) ;
+     MCW_MALLOC_status ;
    }
 
    if( TPR_verb > 1 && nort_fixed > 0 ){
@@ -983,7 +983,7 @@ STATUS("pseudo-inverse of fixed orts") ;
        sprintf(fname,"%s.ort_psinv.1D",tp->prefix) ;
        mri_write_1D(fname,qim) ; mri_clear_and_free(qim) ;
      }
-     (void)mcw_malloc_status("3dTproject.c",__LINE__) ;
+     MCW_MALLOC_status ;
    } else {
      ort_fixed_psinv = NULL ;
    }

--- a/src/3dfim+.c
+++ b/src/3dfim+.c
@@ -1714,7 +1714,9 @@ WARNING_message("This program (3dfim+) is very old, may not be useful, and will 
      if( new_argv != NULL ){ argc = new_argc ; argv = new_argv ; }
    }
 
-  enable_mcw_malloc();
+#ifndef DONT_USE_MCW_MALLOC
+   enable_mcw_malloc();
+#endif
   
   /*----- Program initialization -----*/
   initialize_program (argc, argv, &option_data, &dset_time, &mask_dset, 

--- a/src/3dmask_tool.c
+++ b/src/3dmask_tool.c
@@ -118,7 +118,9 @@ int main( int argc, char *argv[] )
 
    /* general stuff */
    mainENTRY("3dmask_tool"); machdep(); AFNI_logger("3dmask_tool",argc,argv);
+#ifndef DONT_USE_MCW_MALLOC
    enable_mcw_malloc();
+#endif
 
    /* process options: a negative return is considered an error */
    rv = process_opts(params, argc, argv);

--- a/src/3drefit.c
+++ b/src/3drefit.c
@@ -9,6 +9,8 @@
 static ATR_float *Update_float_atr(char *aname, char *fvstring);
 static ATR_int *Update_int_atr(char *aname, char *ivstring);
 
+extern void Obliquity_to_coords(THD_3dim_dataset *);
+
 void Syntax(int detail)
 {
    int ii ;

--- a/src/Makefile.linux_ubuntu_16_64
+++ b/src/Makefile.linux_ubuntu_16_64
@@ -16,7 +16,7 @@ LGIFTI    = -lexpat  #/usr/lib64/libexpat.a
 # L_USE_ACML = /opt/acml3.1.0/gnu64/lib/libacml.a
 
 CCDEBS = -DAFNI_DEBUG -DIMSEQ_DEBUG -DDISPLAY_DEBUG -DTHD_DEBUG
-CEXTRA = -Wcomment -Wformat -DUSE_TRACING -DHAVE_XDBE $(CPROF)
+CEXTRA = -Wcomment -Wformat -DUSE_TRACING -DHAVE_XDBE -D_GNU_SOURCE $(CPROF)
 
 CC     = /usr/bin/gcc -O2 -m64 -fPIC -DREAD_WRITE_64 -DLINUX2 $(CEXTRA)
 CCVOL  = /usr/bin/gcc -O2 -m64 -fPIC -DREAD_WRITE_64 -DLINUX2 $(CEXTRA)

--- a/src/afni_func.c
+++ b/src/afni_func.c
@@ -8,6 +8,7 @@
 
 #include "afni.h"
 #include "afni_plugout.h"
+#include "mcw_malloc.h"
 extern char **Atlas_Names_List(ATLAS_LIST *atl);
 
 static THD_3dim_dataset *atlas_ovdset = NULL;
@@ -7255,9 +7256,9 @@ STATUS("got func info") ;
 
    else if( w == im3d->vwid->dmode->misc_purge_pb ){
      long long mb , ma ;
-     mb = mcw_malloc_total() ;
+     mb = MCW_MALLOC_total ;
      AFNI_purge_dsets( 1 ) ;
-     ma = mcw_malloc_total() ;
+     ma = MCW_MALLOC_total ;
      if( mb > 0 && ma > 0 )
        INFO_message("Purge: before=%s  after=%s  diff=%s",
                     commaized_integer_string(mb) ,

--- a/src/debugtrace.h
+++ b/src/debugtrace.h
@@ -221,7 +221,7 @@ void DBG_sigfunc(int sig)   /** signal handler for fatal errors **/
        fprintf(dfp,"** [[Precompiled binary " SHSTRING ": " __DATE__ "]]\n") ;
 #endif
        fprintf(dfp,"** Program Crash **\n") ;
-       if( mcw_malloc_enabled() && getenv("AFNI_CRASH_MALLDUMP") != NULL )
+       if( MCW_MALLOC_enabled && getenv("AFNI_CRASH_MALLDUMP") != NULL )
          mcw_malloc_dump_fp(dfp) ; /* 23 Apr 2015 */
        fclose(dfp) ;
        fprintf(stderr,"** Crash log is appended to file %s\n",fname) ;
@@ -349,7 +349,7 @@ extern void clock_time_atexit(void) ;
 #define STATUSp(str,p)                                                              \
   do{ char qss[2048] ;                                                              \
       sprintf(qss,"%s ptr=%p",(str),(p)) ;                                          \
-      if( mcw_malloc_enabled() )                                                    \
+      if( MCW_MALLOC_enabled )                                                    \
         strcat(qss, mcw_malloc_OK(p) ? "  OK" : "  not OK") ;                       \
       if( TRACK_TRACING ){                                                          \
         char sbuf[2048] ;                                                           \

--- a/src/float_scan.c
+++ b/src/float_scan.c
@@ -48,6 +48,8 @@
 #define WRITE_BUF \
    do{ fwrite(fbuf,sizeof(float),nbuf,stdout); fflush(stdout); } while(0)
 
+extern long long THD_filesize( char * pathname );
+
 int main( int argc , char * argv[] )
 {
    int iarg=1 , ii , typ ;

--- a/src/help_format.c
+++ b/src/help_format.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <unistd.h>
 
 #define LINE_GAP 9
 

--- a/src/matrix_f.c
+++ b/src/matrix_f.c
@@ -68,11 +68,13 @@
 
 #include "mri_image.h"  /* moved here on 16 May 2005, for OS X Tiger */
 extern MRI_IMAGE *mri_read_1D(char *) ;
+extern void mri_free( MRI_IMAGE *im ) ;
 
 #include <math.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include "matrix_f.h"
+#include "cs.h"
 
 /*---------------------------------------------------------------------*/
 /** Vectorization macros:

--- a/src/mayo_analyze.c
+++ b/src/mayo_analyze.c
@@ -3,6 +3,7 @@
 #include "mayo_analyze.h"
 
 void ShowHdr(char *, struct dsr *);
+void swap_hdr(struct dsr *pntr);
 void swap_long(void *);
 void swap_short(void *);
 
@@ -146,7 +147,7 @@ void ShowHdr(char *fileName, struct dsr *hdr)
 
 }
 
-swap_hdr(struct dsr *pntr)
+void swap_hdr(struct dsr *pntr)
 {
        swap_long(&pntr->hk.sizeof_hdr) ;
        swap_long(&pntr->hk.extents) ;

--- a/src/mcw_malloc.h
+++ b/src/mcw_malloc.h
@@ -52,6 +52,9 @@ extern "C" {
 #undef  mcw_strdup
 #define mcw_strdup  strdup
 
+#undef  mcw_malloc_dump_fp
+#define mcw_malloc_dump_fp(fp) 1
+
 /*---------------------------------------------------------------------------*/
 #else
 

--- a/src/mcw_malloc.h
+++ b/src/mcw_malloc.h
@@ -52,8 +52,7 @@ extern "C" {
 #undef  mcw_strdup
 #define mcw_strdup  strdup
 
-#undef  mcw_malloc_dump_fp
-#define mcw_malloc_dump_fp(fp) 1
+extern void   mcw_malloc_dump_fp(FILE *fp) ;
 
 /*---------------------------------------------------------------------------*/
 #else

--- a/src/mrilib.h
+++ b/src/mrilib.h
@@ -1176,6 +1176,7 @@ extern double * startup_lsqfit( int , float * , int , float *ref[] ) ;
 extern float * delayed_lsqfit( int , float * , int , float *ref[] , double * ) ;
 
 extern void mri_polyfit_verb( int ) ;
+extern void mri_polyfit_set_basis( char *str );
 extern MRI_IMAGE * mri_polyfit( MRI_IMAGE *, int, MRI_IMARR *, byte *, float, int ) ;
 extern MRI_IMAGE * mri_polyfit_byslice( MRI_IMAGE *, int, MRI_IMARR *, byte *, float, int ) ;
 

--- a/src/mrilib.h
+++ b/src/mrilib.h
@@ -1202,6 +1202,8 @@ extern void mri_flatfilter_usedxyz  ( int i ) ;
 void mri_Set_KO_catwrap(void);
 void mri_Set_OK_catwrap(void);
 void mri_Set_OK_catrandwrap(void);
+void mri_Set_OK_WrapZero(byte vv);
+void mri_Set_KO_WrapZero(void);
 extern MRI_IMAGE * mri_cat2D( int,int,int,void *,MRI_IMARR *) ;
 extern MRI_IMARR * mri_uncat2D( int , int , MRI_IMAGE * im ) ; /* 09 May 2000 */
 

--- a/src/niccc.c
+++ b/src/niccc.c
@@ -184,7 +184,7 @@ int main( int argc , char *argv[] )
       ns = NI_stream_open( strm, "r" ) ;
       if( ns == NULL ){
          fprintf(stderr,"*** niccc: NI_stream_open fails for %s\n", strm) ; 
-         if (THD_is_file(strm)) {
+         if (NI_is_file(strm)) {
             fprintf(stderr,
                "  It looks like %s is a file.\n"
                "  Make sure you use option -f before it\n",

--- a/src/niml/niml.h
+++ b/src/niml/niml.h
@@ -610,6 +610,8 @@ extern void   NI_kill_attribute( void *, char * ) ;
 extern void   NI_set_attribute( void *, char *, char * ) ;
 extern char * NI_get_attribute( void *, char * ) ;
 extern char * NI_get_attribute_nocase( void *, char * ) ;           /* 20 Aug 2019 */
+extern void NI_set_dimen( NI_element *nel , int rank , int *nd );
+extern void NI_set_axes( NI_element *nel , char **ax );
 extern void NI_insert_value( NI_element *, int,int, void * );       /* 03 Apr 2003 */
 extern void NI_insert_column_stride( NI_element *nel, int typ, void *arr, int stride, int icol );
 extern void NI_add_column_stride( NI_element *, int, void *, int ); /* 29 May 2003 */

--- a/src/plugout_ijk.c
+++ b/src/plugout_ijk.c
@@ -13,6 +13,8 @@
 
 #include "thd_iochan.h"
 #include "niml.h"
+#include "cs.h"
+#include "afni_environ.h"
 
 /***** Global variable determining on which system AFNI runs.  *****/
 /***** [default is the current system, can be changed by user] *****/

--- a/src/plugout_tt.c
+++ b/src/plugout_tt.c
@@ -57,6 +57,7 @@
 
 #include "thd_iochan.h"
 #include "niml.h"
+#include "afni_environ.h"
 
 /***** Global variable determining on which system AFNI runs.  *****/
 /***** [default is the current system, can be changed by user] *****/

--- a/src/ptaylor/3dTrackID.c
+++ b/src/ptaylor/3dTrackID.c
@@ -127,6 +127,7 @@
 #include "TrackIO.h"
 #include "FuncTrac.h"
 #include "readglob.h"
+#include "checks_and_balances.h"
 
 #include "suma_suma.h"
 

--- a/src/ptaylor/DoTrackit.h
+++ b/src/ptaylor/DoTrackit.h
@@ -86,7 +86,7 @@ int HARDI_Perturb( int *Dim, int ***mskd, int ***INDEX, int ***INDEX2,
 int Two_DOF_Rot( float *X, float *Y, 
                  double POL, double AZIM, float rot[3][3] );
 
-int WritebasicProbFiles( int N_nets, int Ndata, int Nvox, 
+int WriteBasicProbFiles( int N_nets, int Ndata, int Nvox,
                          char *prefix, THD_3dim_dataset *insetFA,
                          int *TV_switch, char *voxel_order, int *NROI,
                          int ***NETROI, int ***mskd, int ***INDEX2, int *Dim,

--- a/src/ptaylor/diffusiony.c
+++ b/src/ptaylor/diffusiony.c
@@ -10,6 +10,7 @@
 #include <gsl/gsl_blas.h>
 #include <gsl/gsl_eigen.h>
 #include <gsl/gsl_sort.h>
+#include <gsl/gsl_linalg.h>
 #include "diffusiony.h"
 
 

--- a/src/ptaylor/diffusiony.h
+++ b/src/ptaylor/diffusiony.h
@@ -91,6 +91,7 @@ int DT_TORTOISEtoAFNI(float **D,
 int GradConv_GmatA_from_Gsign( float *matr, float *grad );
 // assumes I/O has unit or zero mag!
 int GradConv_Gsign_from_GmatA( float *grad, float *matr ); 
+int GradConv_BmatA_from_Bsign( float *matr, float *grad );
 
 int Basic_Grads_to_B7( float **bseven,
                         MRI_IMAGE *flim,

--- a/src/ptaylor/readglob.h
+++ b/src/ptaylor/readglob.h
@@ -23,6 +23,9 @@ static char *DTI_PLUS_LABS[N_DTI_PLUS] = {"P1", "P2", "P3", "P4"};
 static char *DTI_XTRA_LABS[N_DTI_XTRA] = {"XF"};
 
 // ------------------- for DTI globbing -------------------------------
+int glob_for_DTI_vec( char *infix,
+                      THD_3dim_dataset **insetVECS,
+                      int hardi_pref_len);
 
 int glob_for_DTI_trac( char *infix,
                        THD_3dim_dataset **insetPARS,

--- a/src/ptaylor/rsfc.c
+++ b/src/ptaylor/rsfc.c
@@ -2,6 +2,7 @@
 #include <rsfc.h>
 #include <gsl/gsl_vector.h>
 #include <gsl/gsl_sort.h>
+#include <gsl/gsl_sort_vector.h>
 #include <gsl/gsl_permutation.h>
 #include <gsl/gsl_matrix.h>
 #include <gsl/gsl_blas.h>

--- a/src/siemens_vision.c
+++ b/src/siemens_vision.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include "siemens_vision.h"
+#include "mrilib.h"
 
 static void byteswap8 (double *x) {
   char *p1,*p2; double d; int i;

--- a/src/siemens_vision.h
+++ b/src/siemens_vision.h
@@ -1,7 +1,7 @@
 #ifndef _SIEMENS_VISION_HEADER_
 #define _SIEMENS_VISION_HEADER_
 
-#define u_int unsigned int
+typedef unsigned int u_int ;
 #define SIEMENS_HEADERSIZE 6144
 
 struct Siemens_vision_header {

--- a/src/thd_intlist.c
+++ b/src/thd_intlist.c
@@ -7,6 +7,7 @@
 #include "mrilib.h"
 
 extern int *z_rand_order(int bot, int top, long int seed);
+int thd_get_labeltable_intlist(THD_3dim_dataset * dset, char *str);
 
 static int allow_negative = 0 ;
 
@@ -872,8 +873,7 @@ int thd_check_angle_selector(THD_3dim_dataset * dset, char * instr)
       }
    /* handle ,-delimited list of integers/labels */
    } else if ( cptr ) {
-      if( thd_get_labeltable_intlist(dset, rptr, &dset->dblk->master_csv,
-                                                 &dset->dblk->master_ncsv) )
+      if( thd_get_labeltable_intlist(dset, rptr) )
          return 1;
       return 0;
    /* handle single value/label */

--- a/src/to3d.c
+++ b/src/to3d.c
@@ -191,8 +191,10 @@ int main( int argc , char * argv[] )
    INFO_message("It is best to use to3d via the Dimon program.") ;
 
    if( DBG_trace ){                              /* 10 Sep 2002 */
+#ifndef DONT_USE_MCW_MALLOC
      fprintf(stderr,"++ Enabling mcw_malloc()\n") ;
      enable_mcw_malloc() ;
+#endif
    }
 
    /* read the user data from the command line, if any */


### PR DESCRIPTION
Fix all compiler warnings about implicit function declarations (warning: implicit declaration of function) in the default build configuration for Mac OS X 10.14 by including appropriate headers, using macros that were already defined for functions related to mcw_malloc, adding forward declarations, or by calling the correctly named function.