### PR TITLE
add c changes accumulated during build development

### DIFF
--- a/src/f2c.h
+++ b/src/f2c.h
@@ -18,9 +18,7 @@ typedef short int shortint;
 typedef float real;
 typedef double doublereal;
 typedef struct { real r, i; } complex;
-#ifndef _SUNPERF_COMPLEX
 typedef struct { doublereal r, i; } doublecomplex;
-#endif
 typedef long int logical;
 typedef short int shortlogical;
 typedef char logical1;

--- a/src/f2cdir/main.c
+++ b/src/f2cdir/main.c
@@ -43,11 +43,11 @@ extern VOID f_exit();
 
 #ifdef KR_headers
 extern VOID f_init(), sig_die();
-extern int MAIN__();
+/* extern int MAIN__(); */
 #define Int /* int */
 #else
 extern void f_init(void), sig_die(char*, int);
-extern int MAIN__(void);
+/* extern int MAIN__(void); */
 #define Int int
 #endif
 
@@ -91,6 +91,11 @@ sig_die("Trace trap", 1);
 int xargc;
 char **xargv;
 
+#if 0
+/*No executable is built so no main function is needed. Other functions
+defined in this file are required to build the library from this directory
+though
+*/
 #ifdef KR_headers
 main(argc, argv) int argc; char **argv;
 #else
@@ -130,6 +135,8 @@ exit(0);	/* exit(0) rather than return(0) to bypass Cray bug */
 return 0;	/* For compilers that complain of missing return values; */
 		/* others will complain that this is unreachable code. */
 }
+#endif
+
 #ifdef __cplusplus
 	}
 #endif

--- a/src/machdep.c
+++ b/src/machdep.c
@@ -1,7 +1,7 @@
 #define _MCW_MALLOC_HEADER_
 #include "mrilib.h"
 
-#if defined(LINUX)
+#ifndef DARWIN
 # include <malloc.h>
 #endif
 

--- a/src/mcw_malloc.c
+++ b/src/mcw_malloc.c
@@ -745,7 +745,7 @@ void mcw_free( void *fred , char *fnam , int lnum )
 char * mcw_XtMalloc( Cardinal n , char *fnam , int lnum )
 {
    if( use_tracking ) return (char *)malloc_track(n,fnam,lnum) ;
-   else               return (char *)XtMalloc(n) ;
+   else               return (char *)RwcMalloc(n) ;
 }
 
 /*-----------------------------------------------------------------
@@ -762,7 +762,7 @@ char * mcw_XtRealloc( char *p, Cardinal n , char *fnam , int lnum )
    if( use_tracking && (ip=shift_tracker(p)) != NULL )
       return (char*)realloc_track( ip , n , fnam,lnum ) ;
    else
-      return (char*)XtRealloc( p , n ) ;
+      return (char*)RwcRealloc( p , n ) ;
 }
 
 /*----------------------------------------------------------------
@@ -783,7 +783,7 @@ void mcw_XtFree( char *p )
         STATUS(buf) ;
       }
 #endif
-     XtFree(p) ;
+     RwcFree(p) ;
    }
 }
 
@@ -794,5 +794,5 @@ void mcw_XtFree( char *p )
 char * mcw_XtCalloc( Cardinal n , Cardinal m , char *fnam , int lnum )
 {
    if( use_tracking ) return (char *) calloc_track( n , m , fnam,lnum ) ;
-   else               return XtCalloc( n , m ) ;
+   else               return RwcCalloc( n , m ) ;
 }

--- a/src/mcw_malloc.h
+++ b/src/mcw_malloc.h
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <stdint.h>
 
+/* Use mrix for X dependent programs */
 #ifdef __BUILDING_QUICKLOOK_PLUGIN__
   #include "IntrinsicQuickLook.h"
 #else

--- a/src/mri_quantize.c
+++ b/src/mri_quantize.c
@@ -28,7 +28,7 @@ int main( int argc , char * argv[] )
 
 #define MAXCOL 32767
 
-void qsort_int( int , int * , int ) ;
+static void qsort_int_mask( int , int * , int ) ;
 
 MRI_IMAGE * mri_quantize( int newcolors , MRI_IMAGE * im )
 {
@@ -55,7 +55,7 @@ MRI_IMAGE * mri_quantize( int newcolors , MRI_IMAGE * im )
 
    /** sort copy, count unique colors **/
 
-   qsort_int( im->nvox , intar , RGB_MASK ) ;
+   qsort_int_mask( im->nvox , intar , RGB_MASK ) ;
    ncol = 1 ;
    for( ii=1 ; ii < im->nvox ; ii++ )
       if( intar[ii] != intar[ii-1] ) ncol++ ;
@@ -77,7 +77,7 @@ fprintf(stderr,"%d colors in input image\n",ncol) ;
                                  inar[3*ii+1] & mask , inar[3*ii+2] & mask ) ;
 #endif
 
-      qsort_int( im->nvox , intar , RGB_MASK ) ;
+      qsort_int_mask( im->nvox , intar , RGB_MASK ) ;
       ncol = 1 ;
       for( ii=1 ; ii < im->nvox ; ii++ )
          if( intar[ii] != intar[ii-1] ) ncol++ ;
@@ -213,7 +213,7 @@ static void qsrec_int( int n , int * ar , int cutoff , int smask )
 
 /* quick_sort :  sort an array partially recursively, and partially insertion */
 
-void qsort_int( int n , int * a , int smask )
+static void qsort_int_mask( int n , int * a , int smask )
 {
    qsrec_int( n , a , QS_CUTOFF , smask ) ;
    isort_int( n , a , smask ) ;

--- a/src/replaceXt.h
+++ b/src/replaceXt.h
@@ -8,7 +8,9 @@
 #  define offsetof(st, m) ((size_t)&(((st *)0)->m))
 # endif
 
-#undef  REPLACE_XT
+/*---- If REPLACE_XT is defined as a compile flag X11 memory allocation is
+     swapped out for C's malloc. This allows libmri.so to be compiled and
+     linked without X11 as a dependency ---*/
 #ifdef  REPLACE_XT           /* this is the finesse */
 
 typedef   void*           RwcPointer ;
@@ -18,7 +20,7 @@ typedef   void*           RwcPointer ;
 # define  RwcRealloc      realloc
 # define  RwcMalloc       malloc
 # define  RwcNew(t)       ((t *)calloc(1,sizeof(t)))
-# define  RwcNewString(s) (strcpy(malloc(1+strlen(s)),str))
+# define  RwcNewString(s) (strcpy(malloc(1+strlen(s)),s))
 
 #else                        /* this is the crudesse */
 

--- a/src/suma_datasets.h
+++ b/src/suma_datasets.h
@@ -54,7 +54,7 @@
    }  \
 }
 #else
-#define SUMA_DUMP_TRACE(x) /* nada */
+#define SUMA_DUMP_TRACE(...) /* nada */
 #define SUMA_EDUMP_TRACE( ... ) /* nada */
 #endif
 #define SUMA_T_Err SUMA_EDUMP_TRACE

--- a/src/thd_dset_to_vectim.c
+++ b/src/thd_dset_to_vectim.c
@@ -79,8 +79,9 @@ STATUS("create index list") ;
 
    if( ignore > 0 ){  /* extract 1 at a time, save what we want */
 
+     float *var;
 #pragma omp critical (MALLOC)
-     float *var = (float *)malloc(sizeof(float)*(nvals+ignore)) ;
+     var = (float *)malloc(sizeof(float)*(nvals+ignore)) ;
 STATUS("ignore > 0 --> extracting one at a time") ;
      for( kk=iv=0 ; iv < nvox ; iv++ ){
        if( mmm[iv] == 0 ) continue ;
@@ -311,8 +312,9 @@ ENTRY("THD_dset_to_vectim_stend") ;
 
    if( nvals < DSET_NVALS(dset) ){ /* extract 1 at a time, save what we want */
 
+     float *var;
 #pragma omp critical (MALLOC)
-     float *var = (float *)malloc(sizeof(float)*(DSET_NVALS(dset))) ;
+     var = (float *)malloc(sizeof(float)*(DSET_NVALS(dset))) ;
      for( kk=iv=0 ; iv < nvox ; iv++ ){
        if( mmm[iv] == 0 ) continue ;
        (void)THD_extract_array( iv , dset , 0 , var ) ;
@@ -478,8 +480,9 @@ ENTRY("THD_2dset_to_vectim") ;
 
    if( ignore > 0 ){  /* extract 1 at a time, save what we want */
 
+     float *var;
 #pragma omp critical (MALLOC)
-     float *var = (float *)malloc(sizeof(float)*(nvals+ignore)) ;
+     var = (float *)malloc(sizeof(float)*(nvals+ignore)) ;
      mmmt = mmmv[0];
      for( kk=iv=0 ; iv < nvoxv[0] ; iv++ ){
        if( mmmt[iv] == 0 ) continue ;


### PR DESCRIPTION
 REPLACE_XT can now be used to swap out X11's memory allocation.
f2cdir  main.c does not need a main function because it is only
used as part of the f2cdir shared object library.