### PR TITLE
include glut.h with appropriate name spacing

### DIFF
--- a/src/SUMA/SUMA_Makefile_NoDev
+++ b/src/SUMA/SUMA_Makefile_NoDev
@@ -17,7 +17,7 @@ GLWLIB = libGLws.a
 
 ## 07 Dec 2005 -- Modify include path (RWCox)
 
-SUMA_INPATH = ${SUMA_INCLUDE_PATH} -I../nifti/nifti2 -I../nifti/niftilib -I../nifti/nifticdf -I../nifti/znzlib -I../3DEdge/src -I../rickr
+SUMA_INPATH = ${SUMA_INCLUDE_PATH} -I../nifti/nifti2 -I../nifti/niftilib -I../nifti/nifticdf -I../nifti/znzlib -I../3DEdge/src -I../rickr -IGLUT
 
 SUMA_SRCS = SUMA_trackball.c SUMA_SVmanip.c SUMA_input.c \
 		 SUMA_MiscFunc.c SUMA_IV_XYZextract.c	\

--- a/src/SUMA/SUMA_suma.h
+++ b/src/SUMA/SUMA_suma.h
@@ -129,7 +129,7 @@
    #include <GL/gl.h>
    #include <GL/glu.h>
    #include <GL/glx.h>
-   #include <GLUT/GL/glut.h>
+   #include <GL/glut.h>
    
 
    


### PR DESCRIPTION
This is a fix for linux. It still doesn't make a fix for the flat namespacing in the OSX SDK