### PR TITLE
Fix typo in macro _AFNI_SETUP_HEADER_ used as header guard

### DIFF
--- a/src/afni_setup.h
+++ b/src/afni_setup.h
@@ -5,7 +5,7 @@
 ******************************************************************************/
 
 #ifndef _AFNI_SETUP_HEADER_
-#define _AFNI_SETUP_HEADER
+#define _AFNI_SETUP_HEADER_
 
 #include "mcw_malloc.h"
 


### PR DESCRIPTION
Using the CMake build of AFNI on macOS 10.15 with AppleClang, there are 107 instances of header-guard warning:

```
../src/afni_setup.h:7:9: warning: '_AFNI_SETUP_HEADER_' is used as a header guard here, followed by #define of a different macro [-Wheader-guard]
#ifndef _AFNI_SETUP_HEADER_
```

Correcting the defined macro eliminates these warnings.