### PR TITLE
Replace deprecated functions

### DIFF
--- a/src/XmHTML/lib/common/LZWStream.c
+++ b/src/XmHTML/lib/common/LZWStream.c
@@ -777,7 +777,8 @@ LZWStreamInit(LZWStream *lzw)
 	lzw->uncompressed = False;
 
 	/* temporary output file */
-	tmpnam(lzw->zName);
+
+	lzw->zName = mktemp(lzw->zName);
 	strcat(lzw->zName, ".Z");
 
 	/* open it */

--- a/src/plug_delay_V2.h
+++ b/src/plug_delay_V2.h
@@ -15,9 +15,7 @@
 /*-------------------------------------------------------------------*/
 /* taken from #include "/usr/people/ziad/Programs/C/Z/Zlib/prototype.h" */
 
-#if defined(SCO) || defined(SOLARIS)
-#define drem remainder
-#endif
+#include <math.h>
 #ifndef NOWAYXCORCOEF
    #define NOWAYXCORCOEF 0               /* A flag value indicating that something lethal went on */
 #endif
@@ -1087,7 +1085,7 @@ static float punwrap (float p,int opt )
                         error_message ("punwrap","wrong opt parameter",1);
                         exit (1);
                 }
- alf = (float) drem ((double)p,(double)topi);
+ alf = remainderf(p, topi);
  
  if (alf > topi/2.0) alf = topi/2.0-alf;
  

--- a/src/plugout_tta.c
+++ b/src/plugout_tta.c
@@ -471,23 +471,25 @@ static char * axial_ff[] = {
 
 void handle_tta( float xx , float yy , float zz )
 {
-   char * tname ;
+   char tname[] = "ttaXXXXXX.html" ;
    int ii,jj,kk , qqq ;
    static int ii_old=-1 , jj_old=-1 , kk_old=-1 ;
    FILE * fp ;
+   int fd = -1;
    static char nbuf[444] ;
    static char * ttahome ;
 
    /* create temporary URL */
 
    if( url == NULL ){
-      tname = tempnam(NULL,"tta") ;
-      url   = (char *) malloc(strlen(tname)+16) ;
-      uff   = url + 5 ;
-      strcpy(url,"file:") ; strcat(url,tname) ; strcat(url,".html") ;
-      free(tname) ;
-      sprintf(nbuf,"netscape -remote 'openURL(%s)'" , url ) ;
-      fprintf(stderr,"Temporary URL file is %s\n",uff) ;
+      fd = mkstemps(tname, 5) ;
+
+      url = (char *) malloc(strlen(tname)+6) ;
+      uff = url + 5 ;
+      strcpy(url,"file:") ;
+      strcat(url,tname) ;
+      sprintf(nbuf,"netscape -remote 'openURL(%s)'", url ) ;
+      fprintf(stderr,"Temporary URL file is %s\n", uff) ;
 
       ttahome = getenv( "AFNI_TTAPATH" ) ;
       if( ttahome == NULL ) ttahome = TTAHOME ;
@@ -531,7 +533,7 @@ void handle_tta( float xx , float yy , float zz )
 
    /* write out url file */
 
-   fp = fopen( uff , "w" ) ;
+   fp = fdopen( fd , "w" ) ;
    if( fp == NULL ){ fprintf(stderr,"Can't write URL file\n") ; return ; }
 
    fprintf(fp , "<HEAD>\n"


### PR DESCRIPTION
Replace several usages of deprecated functions. The deprecated function `drem` is replaced by the C99 standard function `remainderf`, the deprecated function `tmpnam` is replaced by the POSIX standard function `mktemp`, and the deprecated function `tempnam` is replaced by the function `mkstemps` which is not standard by is available on Linux and macOS platforms at least. These replacements resolve several compiler warnings regarding deprecated declarations.