### PR TITLE
add fix from neurolabusc for lib_system_check.py

### DIFF
--- a/src/python_scripts/afnipy/lib_system_check.py
+++ b/src/python_scripts/afnipy/lib_system_check.py
@@ -71,7 +71,17 @@ class SysInfo:
       dstr = ''
       if   self.system == 'Linux':
          try:    dstr = tostr(platform.linux_distribution())
-         except: checkdist = 1
+         except: 
+            checkdist = 1
+            try: platform.dist()
+            except:
+               checkdist = 0
+               try:
+                  import distro
+                  dstr = tostr(distro.linux_distribution(full_distribution_name=False))
+                  dstr =  ''.join(dstr)
+               except:
+                  pass
       elif self.system == 'Darwin':
          try: dstr = tostr(platform.mac_ver())
          except: checkdist = 1

--- a/tests/scripts/test_with_afni_system_check.py
+++ b/tests/scripts/test_with_afni_system_check.py
@@ -1,8 +1,22 @@
 import pytest
 from .utils.tools import run_cmd
-
+from unittest.mock import MagicMock
+import platform
+from afnipy import lib_system_check as SC
 
 @pytest.mark.slow
 def test_with_afni_system_check(data):
     cmd = "afni_system_check.py -check_all"
     run_cmd(data, cmd)
+
+
+def test_with_afni_system_check_with_dist_deprecated(data):
+    platform.dist = MagicMock(
+        side_effect=AttributeError("module 'platform' has no attribute 'dist'"),
+    )
+    platform.linux_distribution = MagicMock(
+        side_effect=ValueError("Non-specific error to force execution of except clause"),
+    )
+    sinfo = SC.SysInfo()
+    sinfo.show_general_sys_info()
+


### PR DESCRIPTION
Handles the deprecation of platform.dist function in python 3.8.

solves #162 