### PR TITLE
do not create contained time

### DIFF
--- a/.docker/afni_dev_base.dockerfile
+++ b/.docker/afni_dev_base.dockerfile
@@ -3,8 +3,6 @@ FROM neurodebian:nd18.04@sha256:3b3f09ca5387f479f144a2e45fb191afa9c9f7c1bd0f03ac
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
-RUN TZ=Europe/Minsk \
-ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 
 RUN apt-get update && apt-get install -y wget sudo \
@@ -15,9 +13,6 @@ RUN apt-get update && apt-get install -y wget sudo \
 # RUN wget  -O- http://neuro.debian.net/lists/bionic.us-nh.full > /etc/apt/sources.list.d/neurodebian.sources.list && \
 #     apt-key add /usr/local/etc/neurodebian.gpg && \
 #     (apt-key adv --refresh-keys --keyserver hkp://ha.pool.sks-keyservers.net 0xA5D32F012649A5A9 || true)
-
-RUN TZ=Europe/Minsk \
-ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Configure environment
 ENV SHELL=/bin/bash \


### PR DESCRIPTION
Resolves https://github.com/afni/afni/issues/194

A singularity behavior change causes the docker image to now break on some
clusters after conversion to singularity. This change may be reverted in future
versions of singularity. But who needs the time in a container?

https://github.com/hpcng/singularity/issues/5465

EDIT: it's really just the work around that the change in singularity behavior fixes. Otherwise, the images are broken for usage with singularity on systems that bind in this way. Good to know... hopefully its fixed now