### PR TITLE
add fixes for local, test infrastructure path rewriting behavior, and extend cli of run_afni_tests.py

### DIFF
--- a/src/python_scripts/afnipy/afni_base.py
+++ b/src/python_scripts/afnipy/afni_base.py
@@ -528,9 +528,20 @@ class shell_com(object):
          self.capture = capture; #Want stdout and stderr captured?
       self.save_hist = save_hist
 
+      # check if user has requested an overwrite of trimming behavior. If the
+      # variable is set and is not set to a false value then default trimming
+      # behavior is not performed.
+      false_vals = ['no','n','f','false',"0"]
+      mod_request = os.environ.get("NO_CMD_MOD")
+      no_cmd_modiifcation_requested = bool(
+         mod_request and mod_request.lower() not in false_vals
+      )
       #If command line is long, trim it, if possible
       l1 = len(self.com)
-      if (l1 > 80):
+      if no_cmd_modiifcation_requested:
+         # does not modify command to help provide more predictable output
+         self.trimcom = self.com
+      elif (l1 > 80):
          self.trimcom = self.trim()
          #if (len(self.com) < l1):
          #print "Command trimmed to: %s" % (self.com)

--- a/tests/afni_test_utils/container_execution.py
+++ b/tests/afni_test_utils/container_execution.py
@@ -546,6 +546,8 @@ def unparse_args_for_container(tests_dir, **kwargs):
             cmd += f' --extra-args="{v}"'
         elif k == "filter_expr":
             cmd += f' -k="{v}"'
+        elif k == "marker_expression":
+            cmd += f" -m='{v}'"
         elif k == "verbosity":
             cmd += f" -v {v}"
         elif k == "file":

--- a/tests/afni_test_utils/data_management.py
+++ b/tests/afni_test_utils/data_management.py
@@ -110,9 +110,9 @@ def get_base_comparison_dir_path(config_obj):
     """If the user does not provide a comparison directory a default in the
     test data directory is used. The user can specify a directory containing
     the output of a previous test run or the "sample" output that is created
-    by a previous test run when the "--create_sample_output" flag was provided.
+    by a previous test run when the "--create-sample-output" flag was provided.
     """
-    comparison_dir = config_obj.getoption("--diff_with_outdir")
+    comparison_dir = config_obj.getoption("--diff-with-sample")
     if comparison_dir is not None:
         return Path(comparison_dir).absolute()
     else:
@@ -185,8 +185,8 @@ def get_data_fixture(pytestconfig, request, output_dir):
             "tests_data_dir": tests_data_dir,
             "test_name": test_name,
             "rootdir": pytestconfig.rootdir,
-            "create_sample_output": pytestconfig.getoption("--create_sample_output"),
-            "save_sample_output": pytestconfig.getoption("--save_sample_output"),
+            "create_sample_output": pytestconfig.getoption("--create-sample-output"),
+            "save_sample_output": pytestconfig.getoption("--save-sample-output"),
         }
     )
 

--- a/tests/afni_test_utils/minimal_funcs_for_run_tests_cli.py
+++ b/tests/afni_test_utils/minimal_funcs_for_run_tests_cli.py
@@ -100,6 +100,12 @@ def parse_user_args(user_args=None, tests_dir=None):
         help="Make use of all cpus for tests (requires pytest-parallel).",
     )
 
+    thread_management.add_argument(
+        "--trace",
+        help=("Immediately drop into the call stack (the pdb debugger) for each test."),
+        action="store_true",
+    )
+
     parser.add_argument(
         "--ignore-dirty-data",
         action="store_true",
@@ -159,6 +165,53 @@ def parse_user_args(user_args=None, tests_dir=None):
         "-l",
         help=("Only run tests that failed on the last test run."),
         action="store_true",
+    )
+
+    pytest_mod.add_argument(
+        "--runslow",
+        help=("Run default tests and tests marked with 'slow'."),
+        action="store_true",
+    )
+
+    pytest_mod.add_argument(
+        "--runveryslow",
+        help=("Run default tests and tests marked with 'slow' or 'veryslow'."),
+        action="store_true",
+    )
+
+    pytest_mod.add_argument(
+        "--create-sample-output",
+        "-c",
+        help=(
+            "Create sample output instead of running a diff with pre- "
+            "existing output. This is a required step when initially "
+            "writing a test. "
+        ),
+        action="store_true",
+    )
+
+    pytest_mod.add_argument(
+        "--diff-with-sample",
+        help=(
+            "Provide a path of pre-existing output that you wish to "
+            "compare against that is not the default data saved in the "
+            "datalad repository afni_ci_test_data. "
+        ),
+        action="store_true",
+    )
+
+    pytest_mod.add_argument(
+        "--marker-expression",
+        "-m",
+        metavar="EXPR",
+        help=(
+            "Provide an expression for filtering tests using markers. "
+            "This should be quoted if more than one word. It is a "
+            "boolean expression; 'A and B' would run all tests that are "
+            "marked with the A AND B. If you wished to run both types "
+            "of tests you would use 'A or B'. See the pytest help "
+            "documentation for more information."
+        ),
     )
 
     pytest_mod_manual = parser.add_argument_group(PYTEST_MANUAL_HELP)
@@ -593,10 +646,28 @@ def get_test_cmd_args(**kwargs):
         cmd_args.append("--pdb")
 
     if kwargs.get("filter_expr"):
-        cmd_args.append(f"-k={kwargs['filter_expr']}")
+        cmd_args.append(f"""-k='{kwargs["filter_expr"]}'""")
 
     if kwargs.get("log_file_level"):
         cmd_args.append(f"--log-file-level={kwargs['log_file_level']}")
+
+    if kwargs.get("trace"):
+        cmd_args.append("--trace")
+
+    if kwargs.get("runslow"):
+        cmd_args.append("--runslow")
+
+    if kwargs.get("runveryslow"):
+        cmd_args.append("--runveryslow")
+
+    if kwargs.get("create_sample_output"):
+        cmd_args.append("--create-sample-output")
+
+    if kwargs.get("diff_with_sample"):
+        cmd_args.append(f"--diff-with-sample={kwargs.get('diff_with_sample')}")
+
+    if kwargs.get("marker_expression"):
+        cmd_args.append(f"""-m='{kwargs.get("marker_expression")}'""")
 
     if kwargs.get("lf"):
         cmd_args.append("--lf")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,15 @@ try:
 except filelock.Timeout:
     OUTPUT_DIR_NAME_CACHE.read_text()
 
+for pipe in "stdout stderr stdin".split():
+    encodings_patterns = [x.upper() for x in ["utf-8", "utf8"]]
+    if not any(p in getattr(sys, pipe).encoding.upper() for p in encodings_patterns):
+        raise EnvironmentError(
+            "Only utf-8 should be used for character encoding. Please "
+            "change your locale settings as required... LANG_C,LANG_ALL "
+            "etc. "
+        )
+
 
 def pytest_sessionstart(session):
     """called after the ``Session`` object has been created and before performing collection

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,16 +198,6 @@ def pytest_addoption(parser):
             "tested in both python 3 and python 2 "
         ),
     )
-    parser.addoption(
-        "--overwrite_outdir",
-        default="",
-        help=(
-            "Specify a path to an output directory to write to. This is "
-            "not required for a typical run of the test-suite. It can "
-            "be useful to restart tests that are executing resumable "
-            "pipelines though. tested in both python 3 and python 2 "
-        ),
-    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -367,14 +357,9 @@ def get_output_dir(config_obj):
         print(config_obj)
         raise TypeError("A pytest config object was expected")
 
-    user_choice = conf.getoption("--overwrite_outdir")
     rootdir = conf.rootdir
-    if user_choice:
-        output_dir = Path(user_choice)
-    else:
-        output_dir = (
-            Path(rootdir) / "output_of_tests" / OUTPUT_DIR_NAME_CACHE.read_text()
-        )
+
+    output_dir = Path(rootdir) / "output_of_tests" / OUTPUT_DIR_NAME_CACHE.read_text()
     if not output_dir.exists():
         output_dir.mkdir(parents=True)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,14 +63,13 @@ try:
 except filelock.Timeout:
     OUTPUT_DIR_NAME_CACHE.read_text()
 
-for pipe in "stdout stderr stdin".split():
-    encodings_patterns = [x.upper() for x in ["utf-8", "utf8"]]
-    if not any(p in getattr(sys, pipe).encoding.upper() for p in encodings_patterns):
-        raise EnvironmentError(
-            "Only utf-8 should be used for character encoding. Please "
-            "change your locale settings as required... LANG_C,LANG_ALL "
-            "etc. "
-        )
+encodings_patterns = [x.upper() for x in ["utf-8", "utf8"]]
+if not any(p in sys.getdefaultencoding().upper() for p in encodings_patterns):
+    raise EnvironmentError(
+        "Only utf-8 should be used for character encoding. Please "
+        "change your locale settings as required... LANG_C,LANG_ALL "
+        "etc. "
+    )
 
 
 def pytest_sessionstart(session):
@@ -92,6 +91,7 @@ def pytest_generate_tests(metafunc):
         os.environ["DYLD_LIBRARY_PATH"] = "/opt/X11/lib/flat_namespace"
 
     os.environ["AFNI_SPLASH_ANIMATE"] = "NO"
+    os.environ["NO_CMD_MOD"] = "true"
     unset_vars = [
         "AFNI_PLUGINPATH",
         "AFNI_PLUGIN_PATH",

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -2,6 +2,7 @@
 filterwarnings =
     ignore:.* is deprecated.*:DeprecationWarning
     ignore:.* are deprecated.*:PendingDeprecationWarning
+addopts = --strict-markers
 markers =
     slow: marks tests as slow
     veryslow: mark tests as veryslow

--- a/tests/scripts/test_guis.py
+++ b/tests/scripts/test_guis.py
@@ -154,9 +154,7 @@ def test_suma_driving_basic(data, unique_gui_port):
         merge_error_with_output=True,
         skip_output_diff=True,
     )
-    stdout_log, stderr_log = differ.run(
-        x_execution_mode=WRAP_SUMA,
-    )
+    stdout_log, stderr_log = differ.run(x_execution_mode=WRAP_SUMA, workdir=data.outdir)
     stdout = stdout_log.read_text()
     assert not any(pat in stdout for pat in SUMA_FAILURE_PATTERNS)
 
@@ -196,8 +194,6 @@ def test_suma_driving(data, unique_gui_port):
         merge_error_with_output=True,
         skip_output_diff=True,
     )
-    stdout_log, stderr_log = differ.run(
-        x_execution_mode=WRAP_SUMA,
-    )
+    stdout_log, stderr_log = differ.run(x_execution_mode=WRAP_SUMA, workdir=data.outdir)
     stdout = stdout_log.read_text()
     assert not any(pat in stdout for pat in SUMA_FAILURE_PATTERNS)

--- a/tests/scripts/test_testing_script_functionality.py
+++ b/tests/scripts/test_testing_script_functionality.py
@@ -1446,3 +1446,21 @@ def test_wrong_build_dir_raise_file_not_found(monkeypatch):
         afni_test_utils.minimal_funcs_for_run_tests_cli.check_if_cmake_configure_required(
             build_dir
         )
+
+
+def test_no_mod_cmd_var_works(monkeypatch, data):
+    # make a long command with paths that should trigger a trimming response
+    cmd = f"{' '.join([str(data.outdir) for x in range(5)])} "
+    # set to anything but a value that is obviously false will prevent trimming
+    monkeypatch.setenv("NO_CMD_MOD", "True")
+    com = afnipy.afni_base.shell_com(cmd)
+    assert com.com == com.trimcom
+
+    # trimming should occur otherwise
+    monkeypatch.setenv("NO_CMD_MOD", "no")
+    com = afnipy.afni_base.shell_com(cmd)
+    assert com.com != com.trimcom
+
+    monkeypatch.delenv("NO_CMD_MOD")
+    com = afnipy.afni_base.shell_com(cmd)
+    assert com.com != com.trimcom


### PR DESCRIPTION
exposes functionality implemented in pytest's conftest.py in the run_afni_tests.py CLI.


Test output logs are modified at the time of comparison to pre-existing sample data from a previous run. This modification reduces spurious diffs occurring.

Command trimming is disabled for stdout/err. This was causing some issues with spurious diffs in the output logs for tests.

Rewriting of paths has been made more robust (previously it was not always rewriting the paths correctly and the functionality was untested)