### PR TITLE
Fix coverage testing

### DIFF
--- a/.docker/cmake_build.dockerfile
+++ b/.docker/cmake_build.dockerfile
@@ -14,6 +14,9 @@ WORKDIR $AFNI_ROOT/../build
 RUN \
     export CC=`which gcc`;\
     if [[ "$AFNI_WITH_COVERAGE" != "0" ]];then\
+        cd $AFNI_ROOT;\
+        mkdir build;\
+        cd build;\
         export CXXFLAGS="-g -O0 -Wall -W -Wshadow -Wunused-variable -Wunused-parameter -Wunused-function -Wunused -Wno-system-headers -Wno-deprecated -Woverloaded-virtual -Wwrite-strings -fprofile-arcs -ftest-coverage"; \
         export CFLAGS="-g -O0 -Wall -W -fprofile-arcs -ftest-coverage"; \
         export LDFLAGS="-fprofile-arcs -ftest-coverage";\
@@ -29,7 +32,8 @@ RUN \
         $AFNI_ROOT
 
 RUN /bin/bash -oc pipefail \
-'ninja -v 2>&1 | tee verbose_build.log && test ${PIPESTATUS[0]} -eq 0'
+    'if [[ ! "$AFNI_WITH_COVERAGE" == "0" ]];then cd $AFNI_ROOT/build;fi &&\
+    ninja -v 2>&1 | tee verbose_build.log && test ${PIPESTATUS[0]} -eq 0'
 
 # install provided it is not a coverage build (which is much larger and so not installed)
 RUN if [[ "$AFNI_WITH_COVERAGE" == "0" ]];then ninja install && fix-permissions $DESTDIR;fi


### PR DESCRIPTION
@shotgunosine, the build directory is now contained in source for coverage builds in the docker image.

I suspect this will work slightly better but I think full reporting of the coverage still won't work correctly. I think the codecov project directory needs to be set manually to /opt/afni/src. It currently uses the working directory during the tests /opt/afni/src/tests and then possibly /opt/afni/src/build directory. It may be that the codecov/coverage config files need to be moved up one level when the project dir is changed.

The pytest-cov plugin is used. It is configured as part of the pytest call with (this string)[https://github.com/afni/afni/blob/b7f60bb333e8c148ba8f1cda19a0cc5fc22d6d90/tests/afni_test_utils/minimal_funcs_for_run_tests_cli.py#L584]. My understanding is that this causes the coverage python to be used during the tests. The call to codecov subsequently uses the output from this  as well as collating the C coverage files (they are created because of build time flag), and finally uploading it.

The following gives an idea of required tweaks to get it working nicely previously:

```
git log -p 34ec36a79390ffda4d4f4dbeae3510c5bd3f8a60 tests
```

If you want to iterate locally the following should work with the circleci CLI (lack of circleci env variables will cause the upload to fail but otherwise everything should run identically to the cloud). The job has to build before the testing stuff happens so I suggesting using 50 cpus or so:

```
circleci local execute --job=coverage_check-0-5
```