### PR TITLE
Basic MacOS 11.1, ARM CPU, Clang support

### DIFF
--- a/src/DWIstructtensor.c
+++ b/src/DWIstructtensor.c
@@ -26,6 +26,10 @@
    #define INLINE   /**/
 #endif
 
+#if defined(__clang__)	   
+   #include "thd_coords.c"
+#endif
+
 #include "thd_shear3d.h"
 #include "matrix.h"
 #include "mrilib.h"

--- a/src/Makefile.macosx_11.1
+++ b/src/Makefile.macosx_11.1
@@ -1,0 +1,162 @@
+
+# This Makefile is for Mac OS 10.14 for 64 bit AFNI, with local linking.
+# The required libraries for use should come with Xcode and XQuartz.
+#
+# Instead of using fink, you should use homebrew to install the following:
+#
+#    libpng jpeg expat freetype fontconfig openmotif libomp
+#    libxt gsl glib2 pkgconfig, gcc (version 8)
+#
+#
+#   Some edits left to do and rename to 10.14 package local
+
+
+usr_ROOT   = /usr/local
+
+USE_ZLIB  = -DHAVE_ZLIB
+LZLIB     = -lz
+USE_GIFTI = -DHAVE_GIFTI
+LGIFTI    = -lexpat
+
+# ------------------------------
+# python from C
+#IPYTHON     = -I/anaconda2/include/python2.7 -DSELENIUM_READY
+#LPYTHON     = -L/anaconda2/lib/python2.7/config
+#LDPYTHON    = -lpython2.7
+
+# STRINGIFY(x) /miniconda3/include/tcl.h conflicts with thd_ttatlas_query.
+
+#IPYTHON     = -I/Users/chrisrorden/opt/miniconda3/include
+#LPYTHON     = -L/Users/chrisrorden/opt/miniconda3/lib
+#LDPYTHON    = -lpython3.8
+
+# ----------------------------------------------------------------------
+# X configuration
+#
+
+#/opt/X11 x86-64 only, we will use brew to install Motif in /opt/local, e.g. 
+#XROOT   = /opt/X11
+XROOT = /opt/local
+XROOT_I = -I$(XROOT)/include
+XROOT_L = -L$(XROOT)/lib
+
+
+XLIBS = -lXm -ljpeg.9 -lXt
+
+
+#HROOT   = /usr/include
+HROOT = /opt/homebrew
+HROOT_I = -I$(HROOT)/include
+HROOT_L = -L$(HROOT)/lib
+
+
+# ----------------------------------------------------------------------
+
+
+CCDEBS = -DAFNI_DEBUG -DIMSEQ_DEBUG -DDISPLAY_DEBUG -DTHD_DEBUG
+CEXTRA = -m64 -Wcomment -Wformat -DUSE_TRACING -DHAVE_XDBE \
+	 -DDONT_USE_MCW_MALLOC $(LESSTIF_DEFS)
+CC     = /usr/bin/gcc -O2  -DDARWIN $(CEXTRA)
+CCVOL  = $(CC)
+CCFAST = $(CC)
+CCMIN  = /usr/bin/gcc
+CCD    = $(CC) $(CCDEBS)
+CCOLD  = $(CC)
+
+OMPFLAG = -Xpreprocessor -fopenmp -lomp -I"$(brew --prefix libomp)/include" -L"$(brew --prefix libomp)/lib" -DUSE_OMP
+
+SYSTEM_NAME = macos_11.1_local
+INSTALLDIR = $(SYSTEM_NAME)
+
+EXTRA_INSTALL_FILES = $(XROOT)/lib/libXm.4.dylib			  \
+		       $(XROOT)/lib/libjpeg.9.dylib			  \
+		       $(XROOT)/lib/libiconv.2.dylib			  \
+		       $(HROOT)/lib/libgsl.dylib			  \
+		       $(HROOT)/lib/libgslcblas.dylib		  \
+		       /usr/local/lib/libomp.dylib	  \
+		       $(HROOT)/lib/libfreetype.dylib \
+		       $(HROOT)/lib/libpng16.dylib
+#$(HROOT)/lib/libbz2.1.dylib		       
+#$(HROOT_L)/libintl.8.dylib. //<- getopt.c, to see if installed: locate libintl
+#/usr/lib/python2.7/config/libpython2.7.dylib \
+# $(XROOT_L)/gcc/8/lib/libgcc_s.1.dylib		  \
+#$(XROOT_L)/libglib-2.0.0.dylib		  \
+		      
+			  
+EXTRA_INSTALL_COMMANDS = ( cd $(INSTALLDIR) ;                                 \
+                           chmod u+w *.dylib ;                                \
+                           if [ -d $(HOME)/EXTRAPROGS ]; then $(CP) $(HOME)/EXTRAPROGS/* . ; fi ; )
+
+IFLAGS = -I. $(XROOT_I) $(HROOT_I)
+         
+LFLAGS = -L. $(XROOT_L) $(HROOT_L) -Wl,-x -Wl,-multiply_defined -Wl,warning -Wl,-bind_at_load $(LPYTHON)
+
+CCSVD  = $(CCMIN) -m64 -O0
+
+PLUGIN_SUFFIX = so
+PLUGIN_LFLAGS = -m64 -bundle -flat_namespace -undefined suppress -Wl,-x
+PLUGIN_CC     = $(CC) -dynamic -fno-common
+PLFLAGS       = -m64 -dynamic $(LFLAGS)
+
+# include the line below if you want to include vector arith in 3dDeconvolve_f
+# SPECIAL = -framework Accelerate -DUSE_ACCELERATE
+
+AR     = /usr/bin/ar
+RANLIB = /usr/bin/ranlib
+TAR    = /usr/bin/tar
+MKDIR  = /bin/mkdir
+GZIP   = /usr/bin/gzip
+LD     = $(CCMIN)
+
+RM = /bin/rm -f
+MV = /bin/mv -f
+CP = /bin/cp -f
+
+LINT = /usr/bin/lint -a -b -u -v -x $(IFLAGS) $(CCDEFS)
+
+LIBDIR = $(INSTALLDIR)
+SHOWOFF = -DSHOWOFF=$(SYSTEM_NAME)
+
+INSTALL_PREREQ = suma_gts
+# uncomment if the Gnu Scientific Library is installed (libgsl, libgslcblas)
+# GSLPROGS = balloon
+EXPROGS = $(GSLPROGS)
+
+# for dynamic linking
+
+LLIBS  = -lmri -lf2c $(XLIBS) -lXft -lfontconfig \
+         -lpng16 -liconv -lXmu -lXp -lXpm -lXext -lX11      \
+         $(LZLIB) $(LGIFTI) $(LDPYTHON) -lm -lc
+
+# this is called a hack - command to convert dyname -lXm to static for R_io.so
+#RLIB_CONVERT = | sed 's/-lXm/\/usr\/lib\/libXm.a/'
+RLIB_CONVERT = | sed 's/-lXm/\/usr\/local\/lib\/libXm.a/'
+
+# vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+# For suma
+# ZSS Aug. 08. LibGLw.a now made locally and called libGLws.a
+
+SUMA_GL_DYLIB_CMD = -lGL
+
+GLw_IPATH  =
+GLw_LIB = -lGLw
+# uncomment next two lines if you want to use libGLws.a, SUMA's copy of GLw
+GLw_IPATH  = -IGLw_local
+GLw_LIB = libGLws.a
+
+
+SUMA_GLIB_VER = -2.0
+SUMA_INCLUDE_PATH = $(GLw_IPATH) -I.. -I../niml $(IFLAGS) -Igts/src -I${usr_ROOT}/lib/glib-2.0/include -I${usr_ROOT}/include/glib-2.0 
+SUMA_LINK_PATH = $(XROOT_L) $(LFLAGS) -L..
+
+SUMA_LINK_LIB = $(XLIBS) $(GLw_LIB) $(LLIBS) -lGLU -lGL -lmri -lf2c -lmx -L${usr_ROOT}/lib/ -lglib-2.0 $(SUMA_GL_DYLIB_CMD)
+SUMA_MAKEFILE_NAME = SUMA_Makefile
+SUMA_BIN_ARCHIVE = SUMA_MacOSX.tar
+SUMA_MDEFS = 
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+###############################################################
+
+MAKE = make
+include Makefile.INCLUDE

--- a/src/Makefile.macosx_11.1
+++ b/src/Makefile.macosx_11.1
@@ -34,11 +34,21 @@ LGIFTI    = -lexpat
 # X configuration
 #
 
-#/opt/X11 x86-64 only, we will use brew to install Motif in /opt/local, e.g. 
+#XQuartz: /opt/X11 x86-64 only, we will use brew to install Motif in /opt/local, e.g. 
 #XROOT   = /opt/X11
-XROOT = /opt/local
+XROOT   = /opt/local
+#XROOT = /opt/local
 XROOT_I = -I$(XROOT)/include
 XROOT_L = -L$(XROOT)/lib
+
+#does not support ARM: /opt/X11/lib/libX11.dylib
+#macports does:
+# file /Applications/MacPorts/X11.app/Contents/MacOS/X11.bin
+# otool -L /Applications/MacPorts/X11.app/Contents/MacOS/X11.bin
+# file /opt/local/lib/libX11.6.dylib
+
+
+
 
 
 XLIBS = -lXm -ljpeg.9 -lXt
@@ -146,8 +156,8 @@ GLw_LIB = libGLws.a
 
 
 SUMA_GLIB_VER = -2.0
-SUMA_INCLUDE_PATH = $(GLw_IPATH) -I.. -I../niml $(IFLAGS) -Igts/src -I${usr_ROOT}/lib/glib-2.0/include -I${usr_ROOT}/include/glib-2.0 
-SUMA_LINK_PATH = $(XROOT_L) $(LFLAGS) -L..
+SUMA_INCLUDE_PATH = $(GLw_IPATH) -I.. -I../niml $(IFLAGS) -Igts/src -I${usr_ROOT}/lib/glib-2.0/include -I${usr_ROOT}/include/glib-2.0
+SUMA_LINK_PATH =  $(XROOT_L) $(LFLAGS) -L..
 
 SUMA_LINK_LIB = $(XLIBS) $(GLw_LIB) $(LLIBS) -lGLU -lGL -lmri -lf2c -lmx -L${usr_ROOT}/lib/ -lglib-2.0 $(SUMA_GL_DYLIB_CMD)
 SUMA_MAKEFILE_NAME = SUMA_Makefile

--- a/src/Makefile.macosx_11.1notes.txt
+++ b/src/Makefile.macosx_11.1notes.txt
@@ -1,16 +1,22 @@
-cd ~/src/afni/src
-make vastness
+
 
 Install
- 1. gcc not yet available (use Clang)
- 2. OpenMP for Clang must be installed
+ 1. Since Xquartz is not natively compiled for arm64 Macs, one work around is to install xorg via macports (you can actually run AFNI with the translated Xquartz, but SUMA will not compile). Note that macports is unable to build motif natively for arm64, and homebrew is unable to install x11 natively for arm64 macs. Therefore, a full build requires using both tools:
+	Install MacPorts
+	sudo port install xorg
+	sudo port install xorg-server
+	X11.app will be installed in /Applications/MacPorts
+	Potentially profile to avoid exporting DISPLAY=:0
+	Logout and login
+ 2. gcc not yet available (use Clang)
+ 3. OpenMP for Clang must be installed
   a. EITHER Install precompiled version: https://mac.r-project.org/openmp/
   b. OR compile your own
 		git clone https://github.com/llvm/llvm-project.git
 		cd llvm-project/openmp; mkdir build; cd build 
 		cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES='arm64;x86_64' .. 
 		 make install  
- 3. Some libraries will need to be generated
+ 4. Some libraries will need to be generated
   a. Motif must be installed as native library
       export ARCHFLAGS='-arch arm64'
       brew install -s motif
@@ -36,17 +42,19 @@ Install
       export ARCHFLAGS='-arch arm64'
 	  brew install -s libxi
 	 Creates files in "/opt/homebrew/Cellar/libxi/1.7.10/include" and "/opt/homebrew/Cellar/libxi/1.7.10/lib"
- 4. while the headers are not required to compile "vastness", AFNI wants to copy these libraries to the executable folder - perhaps they are dependencies?	
+ 5. while the headers are not required to compile "vastness", AFNI wants to copy these libraries to the executable folder - perhaps they are dependencies?	
     export ARCHFLAGS='-arch arm64'
 	brew install -s freetype
-    brew install -s glib
-	
-  7. brew is unable to create several libraries that the AFNI makefile wants to copy. It is unclear if these are linked to any executables:
+    brew install -s glib	
+ 6. brew is unable to create several libraries that the AFNI makefile wants to copy. It is unclear if these are linked to any executables:
 	cp: /usr/local/lib/gcc/8/lib/libgcc_s.1.dylib: No such file or directory
 	cp: /usr/local/lib/libglib-2.0.0.dylib: No such file or directory
 	cp: /usr/local/lib/libbz2.1.dylib: No such file or directory
 	cp: /usr/local/lib/libintl.8.dylib: No such file or directory
 	libpython*.dylib not native (makefile does not define "LDPYTHON" but not required to build executables)
+ 7. You should now be able to build afni
+	cd ~/afni/src
+	make vastness
 
  
  

--- a/src/Makefile.macosx_11.1notes.txt
+++ b/src/Makefile.macosx_11.1notes.txt
@@ -1,0 +1,54 @@
+cd ~/src/afni/src
+make vastness
+
+Install
+ 1. gcc not yet available (use Clang)
+ 2. OpenMP for Clang must be installed
+  a. EITHER Install precompiled version: https://mac.r-project.org/openmp/
+  b. OR compile your own
+		git clone https://github.com/llvm/llvm-project.git
+		cd llvm-project/openmp; mkdir build; cd build 
+		cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES='arm64;x86_64' .. 
+		 make install  
+ 3. Some libraries will need to be generated
+  a. Motif must be installed as native library
+      export ARCHFLAGS='-arch arm64'
+      brew install -s motif
+	  Creates files in "/opt/local/include" and "/opt/local/lib"
+  b. Unable to install lXpm as native library
+      export ARCHFLAGS='-arch arm64'
+      brew install -s libxpm
+	 Creates files in "/opt/homebrew/Cellar/libxpm"
+  c. files in ./avovk (e.g. 3dkmeans) require gsl
+      export ARCHFLAGS='-arch arm64'
+      brew install -s gsl
+	 Creates files in "/opt/homebrew/Cellar/gsl/2.6/include" and "/opt/homebrew/Cellar/gsl/2.6/lib"
+  d. Suma requires glib must be installed as native library. This will require python3.9, which is not yet available for the M1
+      export ARCHFLAGS='-arch arm64'
+      brew install -s glib
+	 Creates files in "/opt/homebrew/Cellar/glib/2.66.2_1/include" and "/opt/homebrew/Cellar/glib/2.66.2_1/lib"
+  e. Suma requires libGLU and libGL. The versions included with XQuartz (2.7.11, /opt/X11/lib/libGLU.dylib and /opt/X11/lib/libGL.dylib) are not ARM native.
+      export ARCHFLAGS='-arch arm64'
+      brew install -s libGLU       
+	 Creates libGLU.dylib in "/opt/homebrew/Cellar/mesa-glu/9.0.1/include" and "/opt/homebrew/Cellar/mesa-glu/9.0.1/lib" 
+	 It also creates libGL.dylib in "/opt/homebrew/opt/mesa/include" and "/opt/homebrew/opt/mesa/lib"
+  f. Suma requires <X11/XInput.h>:
+      export ARCHFLAGS='-arch arm64'
+	  brew install -s libxi
+	 Creates files in "/opt/homebrew/Cellar/libxi/1.7.10/include" and "/opt/homebrew/Cellar/libxi/1.7.10/lib"
+ 4. while the headers are not required to compile "vastness", AFNI wants to copy these libraries to the executable folder - perhaps they are dependencies?	
+    export ARCHFLAGS='-arch arm64'
+	brew install -s freetype
+    brew install -s glib
+	
+  7. brew is unable to create several libraries that the AFNI makefile wants to copy. It is unclear if these are linked to any executables:
+	cp: /usr/local/lib/gcc/8/lib/libgcc_s.1.dylib: No such file or directory
+	cp: /usr/local/lib/libglib-2.0.0.dylib: No such file or directory
+	cp: /usr/local/lib/libbz2.1.dylib: No such file or directory
+	cp: /usr/local/lib/libintl.8.dylib: No such file or directory
+	libpython*.dylib not native (makefile does not define "LDPYTHON" but not required to build executables)
+
+ 
+ 
+
+

--- a/src/SUMA/SUMA_MiscFunc.c
+++ b/src/SUMA/SUMA_MiscFunc.c
@@ -1,5 +1,11 @@
 #include "SUMA_suma.h"
 
+#if defined(__clang__)	
+extern void   pause_mcw_malloc(void);
+extern void   resume_mcw_malloc(void);
+extern int    mcw_malloc_paused(void);
+#endif
+
 extern SUMA_CommonFields *SUMAg_CF; 
 
 #ifdef USE_SUMA_MALLOC

--- a/src/SUMA/SUMA_Surface_IO.c
+++ b/src/SUMA/SUMA_Surface_IO.c
@@ -2,6 +2,12 @@
 #include "SUMA_suma.h"
 #include "PLY/ply.h"
 
+#if defined(__clang__)	
+extern void   pause_mcw_malloc(void);
+extern void   resume_mcw_malloc(void);
+extern int    mcw_malloc_paused(void);
+#endif
+
 /*!
    \brief a function to simplify loading surfaces the old way
    The only difference with SUMA_Load_Surface_Object_eng is that it 

--- a/src/SUMA/SUMA_display.c
+++ b/src/SUMA/SUMA_display.c
@@ -2,8 +2,13 @@
 #include "coxplot.h"
 #include "SUMA_plot.h"
 
-#if defined(__aarch64__) //TODO: see Ziad's notes from 17, Dec , 2013 regarding glCheckFramebufferStatus()
-#define SUMA_GL_NO_CHECK_FRAME_BUFFER
+#if defined(__clang__) //see Ziad's notes from 17, Dec , 2013 regarding glCheckFramebufferStatus()
+	//XQuartz supports this function, but does not support ARM
+	//#include <GL/glext.h> 
+	// file /usr/X11/lib/libX11.dylib
+	//macports X11 does not support this function, but does support ARM
+    //file /opt/local/lib/libX11.6.dylib
+	#define SUMA_GL_NO_CHECK_FRAME_BUFFER
 #endif
 
 extern int selenium_close(void) ;

--- a/src/SUMA/SUMA_display.c
+++ b/src/SUMA/SUMA_display.c
@@ -2,6 +2,10 @@
 #include "coxplot.h"
 #include "SUMA_plot.h"
 
+#if defined(__aarch64__) //TODO: see Ziad's notes from 17, Dec , 2013 regarding glCheckFramebufferStatus()
+#define SUMA_GL_NO_CHECK_FRAME_BUFFER
+#endif
+
 extern int selenium_close(void) ;
 
 /*! Parts of the code in this file are based on code from the motif programming manual.

--- a/src/SUMA/SUMA_volume_render.c
+++ b/src/SUMA/SUMA_volume_render.c
@@ -3663,7 +3663,11 @@ SUMA_Boolean SUMA_DrawVolumeDO_exp(SUMA_VolumeObject *VO, SUMA_SurfaceViewer *sv
                   if (lbuf[ij]<20) dbuf[ij]=-1.0; /* max it out */
                }
                /* rewrite depth buffer */
+               #if defined(__aarch64__) 
+               //TODO: glWindowPos2s() does not exist!
+               #else
                glWindowPos2s(0,0); /* specify raster position */
+               #endif
                glDrawPixels(sv->X->aWIDTH, sv->X->aHEIGHT, 
                             GL_DEPTH_COMPONENT, GL_FLOAT, dbuf);
                /* render last slice again */

--- a/src/SUMA/SUMA_volume_render.c
+++ b/src/SUMA/SUMA_volume_render.c
@@ -1,4 +1,13 @@
 #include "SUMA_suma.h"
+#undef noglWindowPos2s
+#if defined(__clang__)
+	//XQuartz supports this function, but does not support ARM
+	//#include <GL/glext.h> 
+	// file /usr/X11/lib/libX11.dylib
+	//macports X11 does not support this function, but does support ARM
+	#define noglWindowPos2s
+#endif
+
 
 extern SUMA_CommonFields *SUMAg_CF;
 extern SUMA_DO *SUMAg_DOv;
@@ -3663,11 +3672,11 @@ SUMA_Boolean SUMA_DrawVolumeDO_exp(SUMA_VolumeObject *VO, SUMA_SurfaceViewer *sv
                   if (lbuf[ij]<20) dbuf[ij]=-1.0; /* max it out */
                }
                /* rewrite depth buffer */
-               #if defined(__aarch64__) 
-               //TODO: glWindowPos2s() does not exist!
-               #else
+#ifdef noglWindowPos2s
+			   
+#else
                glWindowPos2s(0,0); /* specify raster position */
-               #endif
+#endif
                glDrawPixels(sv->X->aWIDTH, sv->X->aHEIGHT, 
                             GL_DEPTH_COMPONENT, GL_FLOAT, dbuf);
                /* render last slice again */

--- a/src/plug_delay_V2.h
+++ b/src/plug_delay_V2.h
@@ -15,7 +15,7 @@
 /*-------------------------------------------------------------------*/
 /* taken from #include "/usr/people/ziad/Programs/C/Z/Zlib/prototype.h" */
 
-#if defined(SCO) || defined(SOLARIS)
+#if defined(SCO) || defined(SOLARIS) || defined(__clang__)
 #define drem remainder
 #endif
 #ifndef NOWAYXCORCOEF

--- a/src/ptaylor/basic_boring.c
+++ b/src/ptaylor/basic_boring.c
@@ -1,7 +1,9 @@
 #include "mrilib.h"
 #include "basic_boring.h"
 #include <gsl/gsl_matrix.h>
-
+#if defined(__clang__)	   
+ #include "../afni.h"
+#endif
 
 /* 
    Basic thing to get dimensions of a data set and returned Nvox, just


### PR DESCRIPTION
Minimal changes to support MacOS 11.1, ARM-based Apple Silicon CPUs, Clang compiler.
 - The file `Makefile.macosx_11.1notes.txt` provides instructions for compiling library dependencies from source.
 - All the tools compile, except SUMA.
 - All changes (with the exception of SUMA) use `defined(__clang__)` conditional. Therefore, these should not conflict with gcc builds.
 - Provisional SUMA changes use `defined(__aarch64__)` conditional. These should be reviewed once XQuartz supports this architecture.
 - It is possible to compile SUMA using the [Makefile.macosx_11.01_alpha](https://github.com/neurolabusc/afni/tree/master/src) Makefile. However the resulting project does not work. I suspect the issue is that the libraries in `/opt/X11/` are only compiled for x86-64, and the natively alternatives compiled by homebrew have a few different OpenGL functions ( glWindowPos2s(), glCheckFramebufferStatus()). Hopefully, once XQuartz is available natively it will be easy to compile SUMA. In the meantime, the translated SUMA works fine on M1 macOS.