### PR TITLE
WIP:Add some tweaks to the cmake build for gentoo packaging

### DIFF
--- a/.docker/afni_dev_base.dockerfile
+++ b/.docker/afni_dev_base.dockerfile
@@ -66,7 +66,6 @@ RUN apt-get update && apt-get install -y eatmydata && \
     freeglut3-dev \
     git \
     libf2c2-dev \
-    libglew-dev \
     libglib2.0-dev \
     libglu1-mesa-dev \
     libglw1-mesa-dev \

--- a/.docker/cmake_build.dockerfile
+++ b/.docker/cmake_build.dockerfile
@@ -20,7 +20,7 @@ RUN \
     fi; \
     cmake \
         -GNinja \
-        -DCOMP_BINARIES=ON \
+        -DCOMP_COREBINARIES=ON \
         -DUSE_SYSTEM_NIFTI=OFF \
         -DUSE_SYSTEM_GIFTI=OFF \
         -DCOMP_GUI=ON \

--- a/cmake/afni_project_dependencies.cmake
+++ b/cmake/afni_project_dependencies.cmake
@@ -48,9 +48,9 @@ endif()
 # software isolation then python is only searched for in this environment.
 # For more details see:
 # https://cmake.org/cmake/help/git-stage/module/FindPython.html
-set(CMAKE_FIND_FRAMEWORK LAST)
-set(Python_FIND_VIRTUALENV ONLY)
-set(Python_FIND_STRATEGY LOCATION)
+set_if_not_defined(CMAKE_FIND_FRAMEWORK LAST)
+set_if_not_defined(Python_FIND_VIRTUALENV ONLY)
+set_if_not_defined(Python_FIND_STRATEGY LOCATION)
 
 # python >=3.6 supported
 find_package(Python 3.6 REQUIRED COMPONENTS Interpreter)

--- a/src/XmHTML/CMakeLists.txt
+++ b/src/XmHTML/CMakeLists.txt
@@ -1,17 +1,14 @@
 # TODO: install prefix should be used to distinguish from external library
 cmake_minimum_required(VERSION 3.13)
 project(XmHTML)
-set(CMAKE_BUILD_TYPE "Release")
 
 set(XMHTML_VERSION "1107")
 set(XMHTML_ARCHIVE "1.1.7")
 
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -DNDEBUG")
-
 # Construct XmHTML  library
 add_afni_library(XmHTML "")
 target_compile_definitions(
-  XmHTML PRIVATE "VERSION=${XMHTML_VERSION}" Motif HAVE_LIBJPEG HAVE_REGEX_H
+    XmHTML PRIVATE "VERSION=${XMHTML_VERSION}" Motif HAVE_LIBJPEG HAVE_REGEX_H NDEBUG
 )
 # add headers to XmHTML target_sources
 add_subdirectory(include)


### PR DESCRIPTION
To begin, the cmake variables used to search for the python interpreter at configure time are user modifiable.

Another that detail that we need to solve is python code installation. Ideally this will use the portage distutils-r1 eclass mentioned by @TheChymera. If this works out then COMP_PYTHON should probably be set to off.