### PR TITLE
Change CI test data to repo hosted on GIN

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -558,6 +558,6 @@ workflows:
               test_data_cache_version: ["5"]
           filters:
             tags:
-              only: /AFNI_\d\d.\d.\d\d/
+              ignore: /.*/
             branches:
-              only: /.*/
+              ignore: /.*/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests/afni_ci_test_data"]
 	path = tests/afni_ci_test_data
-	url = https://github.com/afni/afni_ci_test_data.git
+	url = https://gin.g-node.org/leej3/afni_ci_test_data.git

--- a/tests/afni_test_utils/data_management.py
+++ b/tests/afni_test_utils/data_management.py
@@ -64,7 +64,7 @@ def get_tests_data_dir(config_obj):
                 logger.warn("Installing test data")
                 datalad.install(
                     str(tests_data_dir),
-                    "https://github.com/afni/afni_ci_test_data.git",
+                    "https://gin.g-node.org/leej3/afni_ci_test_data.git",
                     recursive=True,
                     on_failure="stop",
                 )

--- a/tests/afni_test_utils/data_management.py
+++ b/tests/afni_test_utils/data_management.py
@@ -64,7 +64,7 @@ def get_tests_data_dir(config_obj):
                 logger.warn("Installing test data")
                 datalad.install(
                     str(tests_data_dir),
-                    "https://gin.g-node.org/leej3/afni_ci_test_data.git",
+                    "https://gin.g-node.org/leej3/afni_ci_test_data",
                     recursive=True,
                     on_failure="stop",
                 )

--- a/tests/afni_test_utils/run_tests_func.py
+++ b/tests/afni_test_utils/run_tests_func.py
@@ -55,10 +55,7 @@ def run_tests(tests_dir, **args_dict):
         # append gcovr to assemble coverage report for C code
         cmd += f"; gcovr -s --xml -o {tests_dir}/gcovr_output.xml -r {args_dict['build_dir']}/src"
         # append command for compiling and uploading codecov report
-
-        # apparently there is a security issue here, must investigate
-        # cmd += "; bash -c 'bash <(curl -s https://codecov.io/bash)'"
-        # sys.exit(1)
+        cmd += "; bash -c 'bash <(curl -s https://codecov.io/bash)'"
 
     print(f"Executing: {cmd}")
     res = subprocess.run(cmd, shell=True, env=os.environ.copy())

--- a/tests/scripts/test_testing_script_functionality.py
+++ b/tests/scripts/test_testing_script_functionality.py
@@ -718,9 +718,7 @@ def test_run_tests_container_subparsers_works(monkeypatch, argslist, mocked_scri
                 "ARGS='{DEFAULT_ARGS} {PYTEST_COV_FLAGS}' "
                 "ninja pytest;"
                 " gcovr -s --xml -o {TESTS_DIR}/gcovr_output.xml -r {params['args_in']['build_dir']}/src;"
-                " echo ======= REFUSING TO GO TO codecov.io ======== "
-                # there may be a security issue with getting the script this way
-                # " bash -c 'bash <(curl -s https://codecov.io/bash)'"
+                " bash -c 'bash <(curl -s https://codecov.io/bash)'"
             ),
         },
     ],


### PR DESCRIPTION
Changes the CI test data repository [leej3/afni_ci_test_data](https://gin.g-node.org/leej3/afni_ci_test_data) hosted at [gin.g-node.org](gin.g-node.org). The repository on GIN does not require access to NIH or afni servers which makes it easier and more accessible to update test data. in the future.

Additionally, this repository is already updated with 3dClusterize data to fix the currently failing tests (Issue #266).