### PR TITLE
Int cmap range

### DIFF
--- a/src/afni_widg.c
+++ b/src/afni_widg.c
@@ -7858,13 +7858,14 @@ char *AFNI_smallest_intpbar(THD_3dim_dataset *dset)
 
    mxset = THD_dset_max(dset, 1);
 
-   if (mxset <= 32) {
+   // [PT: June 25, 2021] these should each cover [0, 31], not [0, 32], etc.
+   if (mxset < 32) {
       return("ROI_i32" ) ;
-   } else if (mxset <= 64) {
+   } else if (mxset < 64) {
       return("ROI_i64" ) ;
-   } else if (mxset <= 128) {
+   } else if (mxset < 128) {
       return("ROI_i128" ) ;
-   } else if (mxset <= 256) {
+   } else if (mxset < 256) {
       return("ROI_i256" ) ;
    }
       /* max is high - use the ROI_i256 colorbar -

--- a/src/pbar.c
+++ b/src/pbar.c
@@ -881,17 +881,19 @@ ENTRY("PBAR_bigmap_finalize") ;
 
    /* If colormap is meant for ROI data, set range
      parameters automatically          ZSS Feb 15 2010 */
+   // [PT, RWC: Jun 25, 2021] set func_range_nval be appropriate for N
+   // rois by having max val being N-1
    if( pbar->parent != NULL ){
      if (strstr(pbar->bigname,"i32")) {
-        AFNI_set_func_range_nval(pbar->parent, MAX(32.0f, fmax));
+        AFNI_set_func_range_nval(pbar->parent, MAX(31.0f, fmax));
      } else if (strstr(pbar->bigname,"i64")) {
-        AFNI_set_func_range_nval(pbar->parent, MAX(64.0f, fmax));
+        AFNI_set_func_range_nval(pbar->parent, MAX(63.0f, fmax));
      } else if (strstr(pbar->bigname,"i128")) {
-        AFNI_set_func_range_nval(pbar->parent, MAX(128.0f, fmax));
+        AFNI_set_func_range_nval(pbar->parent, MAX(127.0f, fmax));
      } else if (strstr(pbar->bigname,"i255")) {
         AFNI_set_func_range_nval(pbar->parent, MAX(255.0f, fmax));
      } else if (strstr(pbar->bigname,"i256")) {
-        AFNI_set_func_range_nval(pbar->parent, MAX(256.0f, fmax));
+        AFNI_set_func_range_nval(pbar->parent, MAX(255.0f, fmax));
      }
    }
 


### PR DESCRIPTION
Up until now, an INT_CMAP with N colors applies to an ROI dset with max value N, and sets its pbar max to also be N.

What *should* happen (and does happen now), is that an INT_CMAP with N colors applies to an ROI dset with max value N-1, and sets its pbar max to also be N-1.