### PR TITLE
Edt

### DIFF
--- a/src/3dEulerDist.c
+++ b/src/3dEulerDist.c
@@ -238,12 +238,6 @@ int run_EDT_3D( int comline, PARAMS_euler_dist opts,
       i = calc_EDT_3D(arr_dist, opts, dset_roi, nn);
       INFO_message("AAA 1b");
 
-      printf("\n\n");
-      for( k=0; k<nz ; k++ ) {
-         if( arr_dist[64][58][k] < 100000 )
-            printf("||%.2f||",  arr_dist[64][58][k]);
-      }
-
       for( i=0 ; i<nx ; i++ )
          for( j=0 ; j<ny ; j++ ) 
             for( k=0; k<nz ; k++ ) {
@@ -312,7 +306,7 @@ int calc_EDT_3D( float ***arr_dist, PARAMS_euler_dist opts,
 {
    int i, j, k, idx;
    float minmax[2] = {0, 0};
-   int nx, ny, nz;
+   int nx, ny, nz, nxy;
 
    float Ledge[3];            // voxel edge lengths ('edims' in lib_EDT.py)
    int vox_ord_rev[3];
@@ -338,6 +332,7 @@ int calc_EDT_3D( float ***arr_dist, PARAMS_euler_dist opts,
    nx = DSET_NX(dset_roi);
    ny = DSET_NY(dset_roi);
    nz = DSET_NZ(dset_roi);
+   nxy = nx*ny;
    Ledge[0] = fabs(DSET_DX(dset_roi)); 
    Ledge[1] = fabs(DSET_DY(dset_roi)); 
    Ledge[2] = fabs(DSET_DZ(dset_roi)); 
@@ -405,25 +400,22 @@ int calc_EDT_3D( float ***arr_dist, PARAMS_euler_dist opts,
 
    // Zero out EDT values in "zero" ROI?
    if( opts.zeros_are_zeroed ) {
-      idx = 0;
       for ( i=0 ; i<nx ; i++ ) 
          for ( j=0 ; j<ny ; j++ ) 
             for ( k=0 ; k<nz ; k++ ){
+               idx = THREE_TO_IJK(i, j, k, nx, nxy);
                if( !THD_get_voxel(dset_roi, idx, ival) )
                   arr_dist[i][j][k] = 0.0;
-               idx++;
             }
    }
 
    // Output distance-squared, or just distance (sqrt of what we have
-   // so-far calc'ed)?
+   // so-far calc'ed)
    if( opts.do_sqrt ) {
-      idx = 0;
       for ( i=0 ; i<nx ; i++ ) 
          for ( j=0 ; j<ny ; j++ ) 
             for ( k=0 ; k<nz ; k++ ){
                arr_dist[i][j][k] = (float) sqrt(arr_dist[i][j][k]);
-               idx++;
             }
    }
     

--- a/src/3dEulerDist.c
+++ b/src/3dEulerDist.c
@@ -113,6 +113,12 @@ int usage_3dEulerDist()
 "                    an open boundary).  Zero-valued ROIs (= background)\n"
 "                    are not affected by this option.\n"
 "\n"
+" -ignore_voxdims   :this EDT algorithm works in terms of physical distance\n"
+"                    and uses the voxel dimension info in each direction, by\n"
+"                    default.  However, using this option will ignore voxel\n"
+"                    size, producing outputs as if each voxel dimension was\n"
+"                    unity.\n"
+"\n"
 "==========================================================================\n"
 "\n"
 "Examples ~1~\n"
@@ -126,13 +132,28 @@ int usage_3dEulerDist()
 "   3dEulerDist                                                     \\\n"
 "       -zeros_are_zero                                             \\\n"
 "       -input  roi_map.nii.gz                                      \\\n"
-"       -prefix roi_map_EDT_NZ.nii.gz                               \n"
+"       -prefix roi_map_EDT_ZZ.nii.gz                               \n"
 "\n"
 "3) Output distance-squared at each voxel:\n"
 "   3dEulerDist                                                     \\\n"
 "       -dist_squared                                               \\\n"
 "       -input  mask.nii.gz                                         \\\n"
 "       -prefix mask_EDT_SQ.nii.gz                                  \n"
+"\n"
+"4) Distinguish ROIs from nonzero background by making the former have\n"
+"   negative distance values in output:\n"
+"   3dEulerDist                                                     \\\n"
+"       -nz_are_neg                                                 \\\n"
+"       -input  roi_map.nii.gz                                      \\\n"
+"       -prefix roi_map_EDT_NZNEG.nii.gz                            \n"
+"\n"
+"5) Have output voxel values represent (number of vox)**2 from a boundary;\n"
+"   voxel dimensions are ignored here:\n"
+"   3dEulerDist                                                     \\\n"
+"       -ignore_voxdims                                             \\\n"
+"       -dist_squared                                               \\\n"
+"       -input  roi_map.nii.gz                                      \\\n"
+"       -prefix roi_map_EDT_SQ_VOX.nii.gz                           \n"
 "\n"
 "==========================================================================\n"
 "\n",
@@ -217,6 +238,11 @@ int main(int argc, char *argv[]) {
 
       if( strcmp(argv[iarg],"-dist_squared") == 0) {
          InOpts.do_sqrt = 0;
+         iarg++ ; continue ;
+      }
+
+      if( strcmp(argv[iarg],"-ignore_voxdims") == 0) {
+         InOpts.ignore_voxdims = 1;
          iarg++ ; continue ;
       }
 

--- a/src/3dEulerDist.c
+++ b/src/3dEulerDist.c
@@ -45,8 +45,6 @@
 #include "3ddata.h"
 #include "thd_euler_dist.c"
 
-#define BIG FLT_MAX     // from float.h
-
 int run_EDT_3D( int comline, PARAMS_euler_dist opts,
                 int argc, char *argv[] );
 int calc_EDT_3D( float ***arr_dist, PARAMS_euler_dist opts,
@@ -296,20 +294,47 @@ int calc_EDT_3D( float ***arr_dist, PARAMS_euler_dist opts,
    i = sort_vox_ord_desc(3, Ledge, vox_ord_rev);
 
    for( i=0 ; i<3 ; i++ ){
-      switch( vox_ord_rev[i] ){
+      float *flarr=NULL;   // store distances along one dim
+      int *maparr=NULL;    // store ROI map along one dim
 
+      switch( vox_ord_rev[i] ){
+         // note pairings per case: 0 and nx; 1 and ny; 2 and nz
       case 0 :
-         j = calc_EDT_3D_dim0( arr_dist, opts, dset_roi, ival );
+         flarr = (float *) calloc( nx, sizeof(float) );
+         maparr = (int *) calloc( nx, sizeof(int) );
+         if( flarr == NULL || maparr == NULL ) 
+            ERROR_exit("MemAlloc failure: flarr/maparr\n");
+         
+         j = calc_EDT_3D_dim0( arr_dist, opts, dset_roi, ival, 
+                               flarr, maparr );
          break;
+
       case 1 :
-         j = calc_EDT_3D_dim1( arr_dist, opts, dset_roi, ival );
+         flarr = (float *) calloc( ny, sizeof(float) );
+         maparr = (int *) calloc( ny, sizeof(int) );
+         if( flarr == NULL || maparr == NULL ) 
+            ERROR_exit("MemAlloc failure: flarr/maparr\n");
+
+         j = calc_EDT_3D_dim1( arr_dist, opts, dset_roi, ival, 
+                               flarr, maparr );
          break;
+
       case 2 :
-         j = calc_EDT_3D_dim2( arr_dist, opts, dset_roi, ival );
+         flarr = (float *) calloc( nz, sizeof(float) );
+         maparr = (int *) calloc( nz, sizeof(int) );
+         if( flarr == NULL || maparr == NULL ) 
+            ERROR_exit("MemAlloc failure: flarr/maparr\n");
+
+         j = calc_EDT_3D_dim2( arr_dist, opts, dset_roi, ival, 
+                               flarr, maparr );
          break;
+
       default:
          WARNING_message("Should never be here in EDT prog");
       }
+
+      if( flarr) free(flarr);
+      if( maparr) free(maparr);
    } // end of looping over axes
 
    // Zero out EDT values in "zero" ROI?

--- a/src/3dEulerDist.c
+++ b/src/3dEulerDist.c
@@ -2,15 +2,12 @@
    Working from P. Lauren's distanceField.c, which was made in
    connection with PA Taylor's Python library for this.
 
-# ==========================================================================
-#
-#
-# ver = 2.0;  date = 'Nov 29, 2021'
-# + [PT] this program has been a longtime coming.  This version merges
-#   P Taylor's Python version in lib_EDT.py with P Lauren's concurrent
-#   work on a C version (which had been compared/developed in part with 
-#   the aformentioned lib_EDT.py).
-#
+ver = 2.0;  date = Nov 29, 2021
++ [PT] this program has been a longtime coming.  This version merges
+  P Taylor's Python version in lib_EDT.py with P Lauren's concurrent
+  work on a C version (which had been compared/developed in part with 
+  the aformentioned lib_EDT.py).
+
 
 */
 
@@ -40,6 +37,13 @@ int usage_3dEulerDist()
 "Overview ~1~ \n"
 "\n"
 "This program calculates the Eulerian Distance Transform (EDT).\n"
+"\n"
+"Basically, this means calculating the Euclidean distance of each\n"
+"voxel's centroid to the nearest boundary  with a separate ROI (well, to be\n"
+"brutally technical, to centroid of the nearest voxel in a neighboring ROI.\n"
+"The input dataset should be a map of ROIs (so, integer-valued). The\n"
+"EDT values are calculated throughout the entire FOV by default,\n"
+"even in the zero/background regions (there is an option to control this).\n"
 "\n"
 "written by: %s\n"
 "\n"
@@ -73,7 +77,7 @@ int usage_3dEulerDist()
 "\n"
 "Command usage and option list ~1~ \n"
 "\n"
-"  3dEulerDist [options] -prefix PREF -input DSET\n"
+"    3dEulerDist [options] -prefix PREF -input DSET\n"
 "\n"
 "where: \n"
 "\n"

--- a/src/3dEulerDist.c
+++ b/src/3dEulerDist.c
@@ -216,7 +216,6 @@ int run_EDT_3D( int comline, PARAMS_euler_dist opts,
    nxy = nx*ny;
    nvox = DSET_NVOX(dset_roi);
    nvals = DSET_NVALS(dset_roi);
-   INFO_message("AAA 0");
 
    arr_dist = (float ***) calloc( nx, sizeof(float **) );
    for ( i=0 ; i<nx ; i++ ) 
@@ -228,15 +227,12 @@ int run_EDT_3D( int comline, PARAMS_euler_dist opts,
       fprintf(stderr, "\n\n MemAlloc failure.\n\n");
       exit(12);
    }
-   INFO_message("AAA 1");
+
    for( nn=0 ; nn<nvals ; nn++ ){
       float *tmp_arr = NULL;
       tmp_arr = (float *) calloc( nvox, sizeof(float) );
 
-      INFO_message("AAA 1a");
-
       i = calc_EDT_3D(arr_dist, opts, dset_roi, nn);
-      INFO_message("AAA 1b");
 
       for( i=0 ; i<nx ; i++ )
          for( j=0 ; j<ny ; j++ ) 
@@ -257,10 +253,7 @@ int run_EDT_3D( int comline, PARAMS_euler_dist opts,
       EDIT_substitute_brick(dset_edt, nn, MRI_float, tmp_arr); 
       tmp_arr=NULL;
     
-
    } // end of loop over nvals
-
-   INFO_message("AAA 2");
 
    // free input dset
 	DSET_delete(dset_roi); 
@@ -277,7 +270,6 @@ int run_EDT_3D( int comline, PARAMS_euler_dist opts,
 	THD_write_3dim_dataset(NULL, NULL, dset_edt, True);
 	DSET_delete(dset_edt); 
   	free(dset_edt); 
-   INFO_message("AAA 3");
 
    // free more
    if(arr_dist){
@@ -288,10 +280,8 @@ int run_EDT_3D( int comline, PARAMS_euler_dist opts,
          free(arr_dist[i]);
       free(arr_dist);
    }
-   INFO_message("AAA 4");
 
-   return 0;   
-
+   return 0;
 }
 
 /*
@@ -421,10 +411,6 @@ int calc_EDT_3D( float ***arr_dist, PARAMS_euler_dist opts,
     
    // at this point, arr_dist should have the correct distance values
    // for this 3D volume
-   for( k=0; k<nz ; k++ ) {
-         if( arr_dist[64][58][k] < 100000 )
-            printf("||%.2f||",  arr_dist[64][58][k]);
-      }
 
    return 0;
 }

--- a/src/3dEulerDist.c
+++ b/src/3dEulerDist.c
@@ -1,0 +1,205 @@
+/* 
+   Working from P. Lauren's distanceField.c, which was made in
+   connection with PA Taylor's Python library for this.
+
+# ==========================================================================
+#
+# This code calculates the Euclidean Distance Transform (EDT) for 3D
+# volumes following this nice, efficient algorithm, by Felzenszwalb
+# and Huttenlocher (2012;  FH2012):
+#
+#   Felzenszwalb PF, Huttenlocher DP (2012). Distance Transforms of
+#   Sampled Functions. Theory of Computing 8:415-428.
+#   https://cs.brown.edu/people/pfelzens/papers/dt-final.pdf
+#
+# Another useful/illustrative resource abotu this is by Philip Rideout:
+#
+#   https://prideout.net/blog/distance_fields/
+#
+# The current code here extends/tweaks the FH2012 algorithm to a more
+# general case of having several different ROIs present, for running
+# in 3D (trivial extension), and for having voxels of non-unity and
+# non-isotropic lengths.  It does this by utilizing the fact that at
+# its very heart, the FH2012 algorithm works line by line and can even
+# be thought of as working boundary-by-boundary.
+#
+# Here, the zero-valued "background" is also just treated like an ROI,
+# with one difference.  At a FOV boundary, the zero-valued
+# ROI/backgroud is treated as open, so that the EDT value at each
+# "zero" voxel is always to one of the shapes within the FOV.  For
+# nonzero ROIs, one can treat the FOV boundary *either* as an ROI edge
+# (EDT value there will be 1 edge length) *or* as being open.
+#
+# written by:  PA Taylor (NIH)
+#
+
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <unistd.h>
+#include <debugtrace.h>
+#include <float.h>
+#include "mrilib.h"
+#include "3ddata.h"
+#include "thd_euler_dist.c"
+
+#define BIG FLT_MAX     // from float.h
+
+int calc_EDT_3D( int comline, PARAMS_euler_dist opts,
+                 int argc, char *argv[] );
+
+// --------------------------------------------------------------------------
+
+int usage_3dEulerDist() 
+{
+   char *author = "P Lauren and PA Taylor";
+
+   printf(
+"\n"
+"Overview ~1~ \n"
+"\n"
+"This program calculates the Eulerian Distance Transform (EDT).\n"
+"\n"
+"written by: %s\n"
+"\n"
+"Description ~2~ \n"
+"\n"
+"\n"
+"==========================================================================\n"
+"\n"
+"Command usage and option list ~1~ \n"
+"\n"
+"  3dEulerDist [something]\n"
+"\n"
+"where: \n"
+"\n"
+"  -input DSET      :(req) input dataset\n"
+"\n"
+"==========================================================================\n"
+"\n"
+"Examples ~1~\n"
+"\n"
+"\n"
+"==========================================================================\n"
+"\n",
+author );
+
+	return 0;
+}
+
+int main(int argc, char *argv[]) {
+
+   int ii = 0;
+   int iarg;
+   PARAMS_euler_dist InOpts;
+
+   mainENTRY("3dEulerDist"); machdep(); 
+  
+   // fill option struct with defaults
+   InOpts = set_euler_dist_defaults();
+
+   // ****************************************************************
+   //                  parse command line arguments
+   // ****************************************************************
+	
+   if (argc == 1) { usage_3dEulerDist(); exit(0); }
+
+   /* scan through args */
+   iarg = 1; 
+   while( iarg < argc && argv[iarg][0] == '-' ){
+
+      if( strcmp(argv[iarg],"-help") == 0 || 
+          strcmp(argv[iarg],"-h") == 0 ) {
+         usage_3dEulerDist();
+         exit(0);
+      }
+			 
+      if( strcmp(argv[iarg],"-input") == 0 ){
+         if( ++iarg >= argc ) 
+            ERROR_exit("Need argument after '%s'", argv[iarg-1]);
+
+         InOpts.input_name = strdup(argv[iarg]) ;
+
+         iarg++ ; continue ;
+      }
+
+      /*
+      if( strcmp(argv[iarg],"-mask") == 0 ){
+         if( ++iarg >= argc ) 
+            ERROR_exit("Need argument after '%s'", argv[iarg-1]);
+
+         dset_mask = THD_open_dataset(argv[iarg]);
+         if( dset_mask == NULL )
+            ERROR_exit("Can't open dataset '%s'", argv[iarg]);
+         DSET_load(dset_mask); CHECK_LOAD_ERROR(dset_mask);
+			
+         iarg++ ; continue ;
+      }
+      */
+
+      if( strcmp(argv[iarg],"-prefix") == 0 ){
+         if( ++iarg >= argc ) 
+            ERROR_exit("Need argument after '%s'", argv[iarg-1]);
+
+         InOpts.prefix = strdup(argv[iarg]) ;
+
+         if( !THD_filename_ok(InOpts.prefix) ) 
+            ERROR_exit("Illegal name after '%s'", argv[iarg-1]);
+         iarg++ ; continue ;
+      }
+
+      if( strcmp(argv[iarg],"-zeros_are_zero") == 0) {
+         InOpts.zeros_are_zeroed = 1;
+         iarg++ ; continue ;
+      }
+
+      if( strcmp(argv[iarg],"-bounds_are_not_zero") == 0) {
+         InOpts.bounds_are_zero = 0;
+         iarg++ ; continue ;
+      }
+
+      if( strcmp(argv[iarg],"-dist_square") == 0) {
+         InOpts.do_sqrt = 1;
+         iarg++ ; continue ;
+      }
+
+      ERROR_message("Bad option '%s'\n",argv[iarg]);
+      suggest_best_prog_option(argv[0], argv[iarg]);
+      exit(1);
+   }
+	
+   // ****************************************************************
+   //               verify presence+behavior of inputs
+   // ****************************************************************
+
+   INFO_message("Starting to check inputs...");
+
+
+   if ( !InOpts.input_name ) { 
+      ERROR_message("You need to provide an input dset with '-input ..'");
+      exit(1);
+   }
+
+   if ( !InOpts.prefix )
+      ERROR_exit("Need an output name via '-prefix ..'\n");
+
+   // DONE FILLING, now call
+   ii = calc_EDT_3D(1, InOpts, argc, argv);
+
+
+   return 0;
+}
+
+
+int calc_EDT_3D( int comline, PARAMS_euler_dist opts,
+                 int argc, char *argv[] )
+{
+
+	THD_3dim_dataset *insetUC = NULL;
+
+
+
+   return 0;
+}

--- a/src/Makefile.INCLUDE
+++ b/src/Makefile.INCLUDE
@@ -156,7 +156,7 @@ PROGS_4  = 3dBlurInMask 3dRank 3dFFT 1dgenARMA11 3dPeriodogram 1dAstrip       \
            3dNwarpXYZ 3dTRfix 3dToyProg 3dRankizer nifti1_tool gifti_tool     \
            cifti_tool images_equal uniq_images tokens 3dLocalACF 3dXClustSim  \
            3dtoXdataset 3dMultiThresh 3dLFCD 3dDegreeCentrality 3dECM 3dMSE   \
-           3dsvm_linpredict 3dTfilter 3dTsplit4D 3dSharpen                    \
+           3dsvm_linpredict 3dTfilter 3dTsplit4D 3dSharpen  3dEulerDist       \
            3dExtractGroupInCorr dcm2niix_afni 3dTto1D 3dBrainSync 3dGrayplot  \
            1dsound afni_check_omp 3dPVmap 3dExchange 3dEdu_01_scale           \
            get_afni_model_PRF get_afni_model_PRF_6 get_afni_model_PRF_6_BAD   \
@@ -275,7 +275,7 @@ LIBHEADERS = mrilib.h mcw_glob.h 3ddata.h thd_maker.h thd_iochan.h             \
              Aomp.h rcmat.h misc_math.h                                        \
              rickr/r_new_resam_dset.h rickr/r_idisp.h rickr/r_misc.h           \
              thd_atlas.h thd_ttatlas_query.h thd_ttatlas_CA_EZ.h               \
-             cs_qsort_small.h thd_depth.h
+             cs_qsort_small.h thd_depth.h thd_euler_dist.h
 
 ### Make everything, install it too, and cleanup
 
@@ -466,6 +466,11 @@ Ifile:Ifile.o
 
 3dGrayplot:3dGrayplot.o
 	$(CC) -o 3dGrayplot 3dGrayplot.o $(LFLAGS) $(LLIBS)
+
+3dEulerDist.o: 3dEulerDist.c thd_euler_dist.c
+
+3dEulerDist:3dEulerDist.o
+	$(CC) -o 3dEulerDist 3dEulerDist.o $(LFLAGS) $(LLIBS)
 
 # not distributed 25 Aug 2020
 3dnoise:3dnoise.o

--- a/src/thd_euler_dist.c
+++ b/src/thd_euler_dist.c
@@ -23,3 +23,53 @@ PARAMS_euler_dist set_euler_dist_defaults(void)
 
    return defopt;
 };
+
+// ---------------------------------------------------------------------------
+
+/*
+  Ledge : (input) array of 3 vox edge lengths
+  ord   : (output) array of 3 indices, describing decreasing vox size
+*/
+int sort_vox_ord_desc(int N, float *Ledge, int *ord)
+{
+   int i;
+   float far[N];
+   int iar[N];
+
+   for( i=0 ; i<N ; i++){
+      far[i] = Ledge[i];
+      iar[i] = i;     // so that we get indices in decreasing order
+   }
+
+   // sorts far in increasing order, carrying along iar values
+   qsort_floatint( N , far , iar );
+   
+   // and we want the 'output' to have the reverse order of iar
+   for( i=0 ; i<N ; i++)
+      ord[i] = iar[N-1-i]; 
+
+   return 0;
+}
+
+// ---------------------------------------------------------------------------
+
+int calc_EDT_3D_dim0( float ***arr_dist, PARAMS_euler_dist opts,
+                      THD_3dim_dataset *dset_roi, int ival)
+{
+
+   return 0;
+}
+
+int calc_EDT_3D_dim1( float ***arr_dist, PARAMS_euler_dist opts,
+                      THD_3dim_dataset *dset_roi, int ival)
+{
+
+   return 0;
+}
+
+int calc_EDT_3D_dim2( float ***arr_dist, PARAMS_euler_dist opts,
+                      THD_3dim_dataset *dset_roi, int ival)
+{
+
+   return 0;
+}

--- a/src/thd_euler_dist.c
+++ b/src/thd_euler_dist.c
@@ -11,6 +11,8 @@ PARAMS_euler_dist set_euler_dist_defaults(void)
    defopt.prefix = NULL;         
 
    defopt.zeros_are_zeroed = 0;  
+   defopt.zeros_are_neg = 0;  
+   defopt.nz_are_neg = 0;  
    defopt.bounds_are_zero = 1;   
    defopt.do_sqrt = 1;           
 

--- a/src/thd_euler_dist.c
+++ b/src/thd_euler_dist.c
@@ -14,6 +14,7 @@ PARAMS_euler_dist set_euler_dist_defaults(void)
    defopt.zeros_are_neg = 0;  
    defopt.nz_are_neg = 0;  
    defopt.bounds_are_zero = 1;   
+   defopt.ignore_voxdims = 0;
    defopt.do_sqrt = 1;           
 
    defopt.edims[0] = 0.0;       
@@ -121,13 +122,18 @@ int calc_EDT_3D( float ***arr_dist, PARAMS_euler_dist opts,
       float *flarr=NULL;   // store distances along one dim
       int *maparr=NULL;    // store ROI map along one dim
 
+      if ( !ival ){
+         INFO_message("Move along axis %d (delta = %.6f)", 
+                      vox_ord_rev[i], 
+                      Ledge[vox_ord_rev[i]]);
+         if( opts.ignore_voxdims )
+            INFO_message("... but this will be ignored, at user behest");
+      }
+
       switch( vox_ord_rev[i] ){
          // note pairings per case: 0 and nx; 1 and ny; 2 and nz
 
       case 0 :
-         if ( !ival )
-            INFO_message("Move along axis %d (delta = %.6f)", 
-                         vox_ord_rev[i], Ledge[vox_ord_rev[i]]);
          flarr = (float *) calloc( nx, sizeof(float) );
          maparr = (int *) calloc( nx, sizeof(int) );
          if( flarr == NULL || maparr == NULL ) 
@@ -138,9 +144,6 @@ int calc_EDT_3D( float ***arr_dist, PARAMS_euler_dist opts,
          break;
 
       case 1 :
-         if ( !ival )
-            INFO_message("Move along axis %d (delta = %.6f)", 
-                         vox_ord_rev[i], Ledge[vox_ord_rev[i]]);
          flarr = (float *) calloc( ny, sizeof(float) );
          maparr = (int *) calloc( ny, sizeof(int) );
          if( flarr == NULL || maparr == NULL ) 
@@ -151,9 +154,6 @@ int calc_EDT_3D( float ***arr_dist, PARAMS_euler_dist opts,
          break;
 
       case 2 :
-         if ( !ival )
-            INFO_message("Move along axis %d (delta = %.6f)", 
-                         vox_ord_rev[i], Ledge[vox_ord_rev[i]]);
          flarr = (float *) calloc( nz, sizeof(float) );
          maparr = (int *) calloc( nz, sizeof(int) );
          if( flarr == NULL || maparr == NULL ) 
@@ -161,7 +161,6 @@ int calc_EDT_3D( float ***arr_dist, PARAMS_euler_dist opts,
 
          j = calc_EDT_3D_dim2( arr_dist, opts, dset_roi, ival, 
                                flarr, maparr );
-         
          break;
 
       default:
@@ -212,7 +211,7 @@ int calc_EDT_3D_dim2( float ***arr_dist, PARAMS_euler_dist opts,
 {
    int ii, jj, kk, idx, ll;
    int nx, ny, nz, nxy;
-   float delta;          // voxel edge length ('edims' element in lib_EDT.py)
+   float delta = 1.0;    // voxel edge length ('edims' element in lib_EDT.py)
 
    ENTRY("calc_EDT_3D_dim2");
 
@@ -220,7 +219,9 @@ int calc_EDT_3D_dim2( float ***arr_dist, PARAMS_euler_dist opts,
    ny = DSET_NY(dset_roi);
    nz = DSET_NZ(dset_roi);
    nxy = nx*ny;
-   delta = fabs(DSET_DZ(dset_roi)); 
+
+   if( !opts.ignore_voxdims )
+      delta = fabs(DSET_DZ(dset_roi)); 
 
    // make appropriate 1D arrays of dist and ROI maps
    for( ii=0 ; ii<nx ; ii++ )
@@ -250,7 +251,7 @@ int calc_EDT_3D_dim1( float ***arr_dist, PARAMS_euler_dist opts,
 {
    int ii, jj, kk, idx, ll;
    int nx, ny, nz, nxy;
-   float delta;          // voxel edge length ('edims' element in lib_EDT.py)
+   float delta = 1.0;    // voxel edge length ('edims' element in lib_EDT.py)
 
    ENTRY("calc_EDT_3D_dim1");
 
@@ -258,7 +259,9 @@ int calc_EDT_3D_dim1( float ***arr_dist, PARAMS_euler_dist opts,
    ny = DSET_NY(dset_roi);
    nz = DSET_NZ(dset_roi);
    nxy = nx*ny;
-   delta = fabs(DSET_DY(dset_roi));
+
+   if( !opts.ignore_voxdims )
+      delta = fabs(DSET_DZ(dset_roi)); 
 
    // make appropriate 1D arrays of dist and ROI maps
    for( ii=0 ; ii<nx ; ii++ )
@@ -288,7 +291,7 @@ int calc_EDT_3D_dim0( float ***arr_dist, PARAMS_euler_dist opts,
 {
    int ii, jj, kk, idx, ll;
    int nx, ny, nz, nxy;
-   float delta;          // voxel edge length ('edims' element in lib_EDT.py)
+   float delta = 1.0;    // voxel edge length ('edims' element in lib_EDT.py)
 
    ENTRY("calc_EDT_3D_dim0");
 
@@ -296,7 +299,9 @@ int calc_EDT_3D_dim0( float ***arr_dist, PARAMS_euler_dist opts,
    ny = DSET_NY(dset_roi);
    nz = DSET_NZ(dset_roi);
    nxy = nx*ny;
-   delta = fabs(DSET_DX(dset_roi));
+
+   if( !opts.ignore_voxdims )
+      delta = fabs(DSET_DZ(dset_roi)); 
 
    // make appropriate 1D arrays of dist and ROI maps
    for( kk=0; kk<nz ; kk++ ) 

--- a/src/thd_euler_dist.c
+++ b/src/thd_euler_dist.c
@@ -68,7 +68,7 @@ int calc_EDT_3D_dim2( float ***arr_dist, PARAMS_euler_dist opts,
 {
    int ii, jj, kk, idx, ll;
    int nx, ny, nz, nxy;
-   float delta;            // voxel edge length ('edims' element in lib_EDT.py)
+   float delta;          // voxel edge length ('edims' element in lib_EDT.py)
 
    ENTRY("calc_EDT_3D_dim2");
 
@@ -76,7 +76,6 @@ int calc_EDT_3D_dim2( float ***arr_dist, PARAMS_euler_dist opts,
    ny = DSET_NY(dset_roi);
    nz = DSET_NZ(dset_roi);
    nxy = nx*ny;
-
    delta = fabs(DSET_DZ(dset_roi)); 
 
    // make appropriate 1D arrays of dist and ROI maps
@@ -93,11 +92,8 @@ int calc_EDT_3D_dim2( float ***arr_dist, PARAMS_euler_dist opts,
                                  delta, opts.bounds_are_zero );
 
          // ... and now put those values back into the distance arr
-         for( kk=0; kk<nz ; kk++ ) {
+         for( kk=0; kk<nz ; kk++ ) 
             arr_dist[ii][jj][kk] = flarr[kk];
-            //if( arr_dist[ii][jj][kk] < 100000 )
-              // printf("||%d, %d: %.2f||", ii, jj, arr_dist[ii][jj][kk]);
-         }
       }
 
    return 0;
@@ -108,8 +104,35 @@ int calc_EDT_3D_dim1( float ***arr_dist, PARAMS_euler_dist opts,
                       THD_3dim_dataset *dset_roi, int ival,
                       float *flarr, int *maparr )
 {
+   int ii, jj, kk, idx, ll;
+   int nx, ny, nz, nxy;
+   float delta;          // voxel edge length ('edims' element in lib_EDT.py)
 
    ENTRY("calc_EDT_3D_dim1");
+
+   nx = DSET_NX(dset_roi);
+   ny = DSET_NY(dset_roi);
+   nz = DSET_NZ(dset_roi);
+   nxy = nx*ny;
+   delta = fabs(DSET_DY(dset_roi));
+
+   // make appropriate 1D arrays of dist and ROI maps
+   for( ii=0 ; ii<nx ; ii++ )
+      for( kk=0; kk<nz ; kk++ ) {
+         for( jj=0 ; jj<ny ; jj++ ) {
+            idx = THREE_TO_IJK(ii, jj, kk, nx, nxy);
+            flarr[jj] = arr_dist[ii][jj][kk];  // note index on flarr
+            maparr[jj] = (int) THD_get_voxel(dset_roi, idx, ival);
+         }
+
+         // update distance along this 1D line...
+         ll = run_EDTD_per_line( flarr, maparr, ny,
+                                 delta, opts.bounds_are_zero );
+
+         // ... and now put those values back into the distance arr
+         for( jj=0; jj<ny ; jj++ )
+            arr_dist[ii][jj][kk] = flarr[jj];
+      }
 
    return 0;
 }
@@ -118,9 +141,35 @@ int calc_EDT_3D_dim0( float ***arr_dist, PARAMS_euler_dist opts,
                       THD_3dim_dataset *dset_roi, int ival,
                       float *flarr, int *maparr )
 {
-   
+   int ii, jj, kk, idx, ll;
+   int nx, ny, nz, nxy;
+   float delta;          // voxel edge length ('edims' element in lib_EDT.py)
+
    ENTRY("calc_EDT_3D_dim0");
 
+   nx = DSET_NX(dset_roi);
+   ny = DSET_NY(dset_roi);
+   nz = DSET_NZ(dset_roi);
+   nxy = nx*ny;
+   delta = fabs(DSET_DX(dset_roi));
+
+   // make appropriate 1D arrays of dist and ROI maps
+   for( kk=0; kk<nz ; kk++ ) 
+      for( jj=0 ; jj<ny ; jj++ ) {
+         for( ii=0 ; ii<nx ; ii++ ) {
+            idx = THREE_TO_IJK(ii, jj, kk, nx, nxy);
+            flarr[ii] = arr_dist[ii][jj][kk];  // note index on flarr
+            maparr[ii] = (int) THD_get_voxel(dset_roi, idx, ival);
+         }
+
+         // update distance along this 1D line...
+         ll = run_EDTD_per_line( flarr, maparr, nx,
+                                 delta, opts.bounds_are_zero );
+
+         // ... and now put those values back into the distance arr
+         for( ii=0; ii<nx ; ii++ )
+            arr_dist[ii][jj][kk] = flarr[ii];
+      }
 
    return 0;
 }

--- a/src/thd_euler_dist.c
+++ b/src/thd_euler_dist.c
@@ -53,23 +53,205 @@ int sort_vox_ord_desc(int N, float *Ledge, int *ord)
 
 // ---------------------------------------------------------------------------
 
-int calc_EDT_3D_dim0( float ***arr_dist, PARAMS_euler_dist opts,
-                      THD_3dim_dataset *dset_roi, int ival)
+/*
+  By construction, flarr has the correct length for each of the
+  dimension calc_EDT_3D_dim?(...) funcs; the calc_EDT_3D_dim2(...)
+  does calcs along the [2]th axis, etc.
+*/
+
+// analyzing along [2]th dimension
+int calc_EDT_3D_dim2( float ***arr_dist, PARAMS_euler_dist opts,
+                      THD_3dim_dataset *dset_roi, int ival,
+                      float *flarr, int *maparr )
 {
+   int ii, jj, kk, idx, ll;
+   int nx, ny, nz, nxy;
+   float delta;            // voxel edge length ('edims' element in lib_EDT.py)
+
+   nx = DSET_NX(dset_roi);
+   ny = DSET_NY(dset_roi);
+   nz = DSET_NZ(dset_roi);
+   nxy = nx*ny;
+
+   delta = fabs(DSET_DZ(dset_roi)); 
+
+   // make appropriate 1D arrays of dist and ROI maps
+   for( ii=0 ; ii<nx ; ii++ )
+      for( jj=0 ; jj<ny ; jj++ ) {
+         for( kk=0; kk<nz ; kk++ ) {
+            idx = THREE_TO_IJK(ii, jj, kk, nx, nxy);
+            flarr[kk] = arr_dist[ii][jj][kk];  // note index on flarr
+            maparr[kk] = (int) THD_get_voxel(dset_roi, idx, ival);
+            }
+         ll = run_EDTD_per_line( flarr, maparr, nz,
+                                 delta, opts.bounds_are_zero );
+         }
+
+
 
    return 0;
 }
+
 
 int calc_EDT_3D_dim1( float ***arr_dist, PARAMS_euler_dist opts,
-                      THD_3dim_dataset *dset_roi, int ival)
+                      THD_3dim_dataset *dset_roi, int ival,
+                      float *flarr, int *maparr )
 {
 
    return 0;
 }
 
-int calc_EDT_3D_dim2( float ***arr_dist, PARAMS_euler_dist opts,
-                      THD_3dim_dataset *dset_roi, int ival)
+int calc_EDT_3D_dim0( float ***arr_dist, PARAMS_euler_dist opts,
+                      THD_3dim_dataset *dset_roi, int ival,
+                      float *flarr, int *maparr )
 {
+   
+
 
    return 0;
+}
+
+int run_EDTD_per_line( float *dist2_line, int *roi_line, int Na,
+                       float delta, int bounds_are_zero )
+{
+   int  idx = 0;
+   int  i, m, n;
+   float *line_out = NULL;
+   int start, stop, inc, roi;
+   
+   float *Df = NULL;
+   
+   int limit = Na-1;
+   size_t  rowLengthInBytes = Na*sizeof(float);
+   
+   if (!(line_out=(float *)malloc(rowLengthInBytes)))
+      ERROR_exit("Memory allocation problem: line_out");
+   
+   while (idx < Na){
+      // get interval of line with current ROI value
+      roi = roi_line[idx];
+      n = idx;
+      while (n < Na){
+         if (roi_line[n] != roi){
+            break;
+         }
+         n += 1;
+      }
+      n -= 1;
+      // n now has the index of last matching element
+
+      float *paddedLine=(float *)calloc(Na+2,sizeof(float));
+      // actual ROI is in range of indices [start, stop] in
+      // paddedLine.  'inc' will tell us length of distance array
+      // put into Euclidean_DT_delta(), which can include padding at
+      // either end.
+      start = 0;
+      stop  = limit; 
+      inc   = 0;
+
+      if (idx != 0 || (bounds_are_zero && roi != 0)){
+         start = 1;
+         inc = 1;
+      }
+      // put actual values from dist**2 field...
+      for ( m=idx; m<=n; ++m ){
+         paddedLine[inc++] = dist2_line[m];
+      }
+      // inc finishes 1 greater than the actual end: is length so far
+      stop = inc-1;  // 'stop' is index of actual end of roi
+      // pad at end? 
+      if (n < limit || (bounds_are_zero && roi != 0)){
+         inc+=1;
+      }
+
+      // [PT] and 'inc' should already have correct value from
+      // above; don't add 1 here
+      Df = Euclidean_DT_delta(paddedLine, inc, delta);
+
+      memcpy(&(line_out[idx]), &(Df[start]), (stop-start+1)*sizeof(float));
+
+      if( paddedLine )
+         free(paddedLine);
+      if( Df )
+         free(Df);
+
+      idx = n+1;
+   }
+
+   // DEBUG
+   for ( i=0; i<Na; ++i ) 
+      if (line_out[i]==0){
+         fprintf(stderr, "Zero valued distance\n");
+      }
+   
+   memcpy(dist2_line, line_out, rowLengthInBytes);
+   if( line_out )
+      free(line_out);
+   
+   return 0;
+}
+
+float * Euclidean_DT_delta(float *f, int n, float delta)
+{
+   //    Classical Euclidean Distance Transform (EDT) of Felzenszwalb and
+   //        Huttenlocher (2012), but for given voxel lengths.
+   //
+   //    Assumes that: len(f) < sqrt(10**10).
+   //
+   //    In this version, all voxels should have equal length, and units
+   //    are "edge length" or "number of voxels."
+   //
+   //    Parameters
+   //    ----------
+   //
+   //    f     : 1D array or list, distance**2 values (or, to start, binarized
+   //    between 0 and BIG).
+   //
+   //    delta : voxel edge length size along a particular direction
+
+   int q;
+   int *v=NULL;
+   int k = 0;
+   float *z=NULL, *Df=NULL;
+   float s;
+
+   if (!(v=(int *)calloc(n, sizeof(int))) ||
+       !(z=(float *)calloc(n+1, sizeof(float)))){
+      if (v) free(v);
+      return NULL;
+   }
+   z[0] = -BIG;
+   z[1] =  BIG;
+
+   for ( q = 1; q<n; ++q ) {
+      s = f[q] + pow(q*delta, 2.0) - (f[v[k]] + pow(v[k]*delta,2.0));
+      s/= 2. * delta * (q - v[k]);
+      while (s <= z[k]){
+         k-= 1;
+         s = f[q] + pow(q*delta,2.0) - (f[v[k]] + pow(v[k]*delta, 2.0));
+         s/= 2. * delta * (q - v[k]);
+      }
+      k+= 1;
+      v[k]   = q;
+      z[k]   = s;
+      z[k+1] = BIG;
+   }
+
+   k   = 0;
+   if (!(Df=(float *)calloc(n, sizeof(float)))){
+      free(v);
+      free(z);
+      return NULL;
+   }
+   for ( q=0; q<n; ++q ){
+      while (z[k+1] < q * delta) k+= 1;
+      Df[q] = pow(delta*(q - v[k]), 2.0) + f[v[k]];
+   }
+
+   if( v )
+      free(v);
+   if( z )
+      free(z);
+
+   return Df;
 }

--- a/src/thd_euler_dist.c
+++ b/src/thd_euler_dist.c
@@ -1,0 +1,25 @@
+#include "mrilib.h" 
+#include "thd_euler_dist.h"
+
+PARAMS_euler_dist set_euler_dist_defaults(void)
+{
+
+   PARAMS_euler_dist defopt;
+
+   defopt.input_name = NULL;     
+   defopt.prefix = NULL;         
+
+   defopt.zeros_are_zeroed = 0;  
+   defopt.bounds_are_zero = 1;   
+   defopt.do_sqrt = 1;           
+
+   defopt.edims[0] = 0.0;       
+   defopt.edims[1] = 0.0;
+   defopt.edims[2] = 0.0;
+
+   defopt.shape[0] = 0; 
+   defopt.shape[1] = 0; 
+   defopt.shape[2] = 0; 
+
+   return defopt;
+};

--- a/src/thd_euler_dist.c
+++ b/src/thd_euler_dist.c
@@ -36,6 +36,8 @@ int sort_vox_ord_desc(int N, float *Ledge, int *ord)
    float far[N];
    int iar[N];
 
+   ENTRY("sort_vox_ord_desc");
+
    for( i=0 ; i<N ; i++){
       far[i] = Ledge[i];
       iar[i] = i;     // so that we get indices in decreasing order
@@ -68,6 +70,8 @@ int calc_EDT_3D_dim2( float ***arr_dist, PARAMS_euler_dist opts,
    int nx, ny, nz, nxy;
    float delta;            // voxel edge length ('edims' element in lib_EDT.py)
 
+   ENTRY("calc_EDT_3D_dim2");
+
    nx = DSET_NX(dset_roi);
    ny = DSET_NY(dset_roi);
    nz = DSET_NZ(dset_roi);
@@ -83,11 +87,18 @@ int calc_EDT_3D_dim2( float ***arr_dist, PARAMS_euler_dist opts,
             flarr[kk] = arr_dist[ii][jj][kk];  // note index on flarr
             maparr[kk] = (int) THD_get_voxel(dset_roi, idx, ival);
             }
+
+         // update distance along this 1D line...
          ll = run_EDTD_per_line( flarr, maparr, nz,
                                  delta, opts.bounds_are_zero );
+
+         // ... and now put those values back into the distance arr
+         for( kk=0; kk<nz ; kk++ ) {
+            arr_dist[ii][jj][kk] = flarr[kk];
+            //if( arr_dist[ii][jj][kk] < 100000 )
+              // printf("||%d, %d: %.2f||", ii, jj, arr_dist[ii][jj][kk]);
          }
-
-
+      }
 
    return 0;
 }
@@ -98,6 +109,8 @@ int calc_EDT_3D_dim1( float ***arr_dist, PARAMS_euler_dist opts,
                       float *flarr, int *maparr )
 {
 
+   ENTRY("calc_EDT_3D_dim1");
+
    return 0;
 }
 
@@ -106,6 +119,7 @@ int calc_EDT_3D_dim0( float ***arr_dist, PARAMS_euler_dist opts,
                       float *flarr, int *maparr )
 {
    
+   ENTRY("calc_EDT_3D_dim0");
 
 
    return 0;
@@ -124,6 +138,8 @@ int run_EDTD_per_line( float *dist2_line, int *roi_line, int Na,
    int limit = Na-1;
    size_t  rowLengthInBytes = Na*sizeof(float);
    
+   //ENTRY("run_EDTD_per_line");
+
    if (!(line_out=(float *)malloc(rowLengthInBytes)))
       ERROR_exit("Memory allocation problem: line_out");
    

--- a/src/thd_euler_dist.c
+++ b/src/thd_euler_dist.c
@@ -7,6 +7,7 @@ PARAMS_euler_dist set_euler_dist_defaults(void)
    PARAMS_euler_dist defopt;
 
    defopt.input_name = NULL;     
+   defopt.mask_name = NULL;     
    defopt.prefix = NULL;         
 
    defopt.zeros_are_zeroed = 0;  

--- a/src/thd_euler_dist.h
+++ b/src/thd_euler_dist.h
@@ -34,6 +34,8 @@ typedef struct {
    char *prefix;          
 
    int zeros_are_zeroed;  
+   int zeros_are_neg;  
+   int nz_are_neg;  
    int bounds_are_zero;   
    int do_sqrt;           
 

--- a/src/thd_euler_dist.h
+++ b/src/thd_euler_dist.h
@@ -1,7 +1,7 @@
 #ifndef THD_EDT_INCLUDED
 #define THD_EDT_INCLUDED
 
-#define BIG FLT_MAX     // from float.h
+#define BIG (100000000000.) //FLT_MAX     // from float.h
 
 
 /* struct of quantities for running Euler Distance Transform (EDT) 

--- a/src/thd_euler_dist.h
+++ b/src/thd_euler_dist.h
@@ -23,6 +23,12 @@
                    EDT values are still calculated everywhere; it is just
                    a question of zeroing out later (no time saved for True).
 
+    ignore_voxdims : we have implemented an EDT alg that works in
+                   terms of physical distance and can use the voxel dimension
+                   info in each direction.  However, users might want 'depth'
+                   just in voxel units (so, delta=1 everywhere), which 
+                   using this option will give 'em.                   
+
     edims        : (len=3 fl arr) element dimensions (here, voxel edge lengths)
 
     shape        : (len=3 int arr) matrix size in each direction
@@ -37,6 +43,7 @@ typedef struct {
    int zeros_are_neg;  
    int nz_are_neg;  
    int bounds_are_zero;   
+   int ignore_voxdims;
    int do_sqrt;           
 
    float edims[3];        

--- a/src/thd_euler_dist.h
+++ b/src/thd_euler_dist.h
@@ -51,6 +51,12 @@ PARAMS_euler_dist set_euler_dist_defaults(void);
 
 int sort_vox_ord_desc(int N, float *Ledge, int *ord);
 
+int apply_opts_to_edt_arr( float ***arr_dist, PARAMS_euler_dist opts,
+                           THD_3dim_dataset *dset_roi, int ival);
+
+int calc_EDT_3D( float ***arr_dist, PARAMS_euler_dist opts,
+                 THD_3dim_dataset *dset_roi, int ival);
+
 int calc_EDT_3D_dim0( float ***arr_dist, PARAMS_euler_dist opts,
                       THD_3dim_dataset *dset_roi, int ival,
                       float *flarr, int *maparr );

--- a/src/thd_euler_dist.h
+++ b/src/thd_euler_dist.h
@@ -1,6 +1,7 @@
 #ifndef THD_EDT_INCLUDED
 #define THD_EDT_INCLUDED
 
+#define BIG FLT_MAX     // from float.h
 
 
 /* struct of quantities for running Euler Distance Transform (EDT) 
@@ -49,11 +50,18 @@ PARAMS_euler_dist set_euler_dist_defaults(void);
 int sort_vox_ord_desc(int N, float *Ledge, int *ord);
 
 int calc_EDT_3D_dim0( float ***arr_dist, PARAMS_euler_dist opts,
-                      THD_3dim_dataset *dset_roi, int ival);
+                      THD_3dim_dataset *dset_roi, int ival,
+                      float *flarr, int *maparr );
 int calc_EDT_3D_dim1( float ***arr_dist, PARAMS_euler_dist opts,
-                      THD_3dim_dataset *dset_roi, int ival);
+                      THD_3dim_dataset *dset_roi, int ival,
+                      float *flarr, int *maparr );
 int calc_EDT_3D_dim2( float ***arr_dist, PARAMS_euler_dist opts,
-                      THD_3dim_dataset *dset_roi, int ival);
+                      THD_3dim_dataset *dset_roi, int ival,
+                      float *flarr, int *maparr );
 
+int run_EDTD_per_line( float *dist2_line, int *roi_line, int Na,
+                       float delta, int bounds_are_zero );
+
+float * Euclidean_DT_delta(float *f, int n, float delta);
 
 #endif

--- a/src/thd_euler_dist.h
+++ b/src/thd_euler_dist.h
@@ -1,7 +1,7 @@
 #ifndef THD_EDT_INCLUDED
 #define THD_EDT_INCLUDED
 
-#define BIG (100000000000.) //FLT_MAX     // from float.h
+#define BIG FLT_MAX     // from float.h
 
 
 /* struct of quantities for running Euler Distance Transform (EDT) 

--- a/src/thd_euler_dist.h
+++ b/src/thd_euler_dist.h
@@ -30,7 +30,7 @@
 typedef struct {
 
    char *input_name;      
-
+   char *mask_name;      
    char *prefix;          
 
    int zeros_are_zeroed;  

--- a/src/thd_euler_dist.h
+++ b/src/thd_euler_dist.h
@@ -62,6 +62,6 @@ int calc_EDT_3D_dim2( float ***arr_dist, PARAMS_euler_dist opts,
 int run_EDTD_per_line( float *dist2_line, int *roi_line, int Na,
                        float delta, int bounds_are_zero );
 
-float * Euclidean_DT_delta(float *f, int n, float delta);
+float * Euclidean_DT_delta(float *f0, int n, float delta);
 
 #endif

--- a/src/thd_euler_dist.h
+++ b/src/thd_euler_dist.h
@@ -1,0 +1,48 @@
+#ifndef THD_EDT_INCLUDED
+#define THD_EDT_INCLUDED
+
+
+
+/* struct of quantities for running Euler Distance Transform (EDT) 
+
+    do_sqrt      : if True, the output image of EDT values is distance
+                   values; otherwise, the values are distance**2 (because
+                   that is what the program works with).
+
+    bounds_are_zero : switch for how to treat FOV boundaries for
+                   nonzero-ROIs; True means they are ROI boundaries
+                   (so FOV is a "closed" boundary for the ROI), and
+                   False means that the ROI continues "infinitely" at
+                   FOV boundary (so it is "open").  Zero-valued ROIs
+                   (= background) are not affected by this value.
+
+    zeros_are_zeroed : if False, EDT values are output for the
+                   zero-valued region; otherwise, zero them out, so EDT
+                   values are only reported in the non-zero ROIs. NB: the
+                   EDT values are still calculated everywhere; it is just
+                   a question of zeroing out later (no time saved for True).
+
+    edims        : (len=3 fl arr) element dimensions (here, voxel edge lengths)
+
+    shape        : (len=3 int arr) matrix size in each direction
+*/
+typedef struct {
+
+   char *input_name;      
+
+   char *prefix;          
+
+   int zeros_are_zeroed;  
+   int bounds_are_zero;   
+   int do_sqrt;           
+
+   float edims[3];        
+   int   shape[3];        
+
+} PARAMS_euler_dist;
+
+/* function to initialize EDT params */
+PARAMS_euler_dist set_euler_dist_defaults(void);
+
+
+#endif

--- a/src/thd_euler_dist.h
+++ b/src/thd_euler_dist.h
@@ -44,5 +44,16 @@ typedef struct {
 /* function to initialize EDT params */
 PARAMS_euler_dist set_euler_dist_defaults(void);
 
+// ---------------------------------------------------------------------------
+
+int sort_vox_ord_desc(int N, float *Ledge, int *ord);
+
+int calc_EDT_3D_dim0( float ***arr_dist, PARAMS_euler_dist opts,
+                      THD_3dim_dataset *dset_roi, int ival);
+int calc_EDT_3D_dim1( float ***arr_dist, PARAMS_euler_dist opts,
+                      THD_3dim_dataset *dset_roi, int ival);
+int calc_EDT_3D_dim2( float ***arr_dist, PARAMS_euler_dist opts,
+                      THD_3dim_dataset *dset_roi, int ival);
+
 
 #endif


### PR DESCRIPTION
3dEulerDist:  a program for calculating the Euler Distance Transform (EDT) in C code.

This code calculates the Euclidean Distance Transform (EDT) for 3D
volumes following this nice, efficient algorithm, by Felzenszwalb
and Huttenlocher (2012;  FH2012):

Felzenszwalb PF, Huttenlocher DP (2012). Distance Transforms of
Sampled Functions. Theory of Computing 8:415-428.
https://cs.brown.edu/people/pfelzens/papers/dt-final.pdf

Another useful/illustrative resource about this is by Philip Rideout:

   https://prideout.net/blog/distance_fields/

The current code here extends/tweaks the FH2012 algorithm to a more
general case of having several different ROIs present, for running
in 3D (trivial extension), and for having voxels of non-unity and
non-isotropic lengths.  It does this by utilizing the fact that at
its very heart, the FH2012 algorithm works line by line and can even
be thought of as working boundary-by-boundary.

Here, the zero-valued "background" is also just treated like an ROI,
with one difference.  At a FOV boundary, the zero-valued
ROI/backgroud is treated as open, so that the EDT value at each
"zero" voxel is always to one of the shapes within the FOV.  For
nonzero ROIs, one can treat the FOV boundary *either* as an ROI edge
(EDT value there will be 1 edge length) *or* as being open.

This code follows the earlier lib_EDT.py library version written by PA Taylor and earlier distanceField program by P Lauren.