### PR TITLE
Add .mailmap for more adequate  git shortlog -sn and unified naming in log

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,34 @@
+Daniel Glen <glend@mail.nih.gov>
+Daniel Glen <glend@mail.nih.gov> dglen <>
+Gang Chen <gangchen@mail.nih.gov>
+Gang Chen <gangchen@mail.nih.gov> gangc <>
+Gang Chen <gangchen@mail.nih.gov> <gangchen@mail.nih.gov>
+Gang Chen <gangchen@mail.nih.gov> <gangc@morgoth.nimh.nih.gov>
+John Lee <johnleenimh@gmail.com>
+John Lee <johnleenimh@gmail.com> <johnleenimh+git@gmail.com>
+John Lee <johnleenimh@gmail.com> <johnleenimh+kraken@gmail.com>
+John Lee <johnleenimh@gmail.com> leej3 <our email address>
+John Lee <johnleenimh@gmail.com> <leej3@users.noreply.github.com>
+Paul Taylor <neon.taylor@gmail.com>
+Paul Taylor <neon.taylor@gmail.com> <paul@Pauls-MacBook-Pro-2.local>
+Paul Taylor <neon.taylor@gmail.com> <paul@Pauls-MacBook-Pro.local>
+Paul Taylor <neon.taylor@gmail.com> <pault>
+Rick Reynolds <reynoldr@mail.nih.gov>
+Rick Reynolds <reynoldr@mail.nih.gov> afni-rickr <reynoldr@mail.nih.gov>
+Rick Reynolds <reynoldr@mail.nih.gov> rickr <>
+Rick Reynolds <reynoldr@mail.nih.gov> <rickr@localhost.localdomain>
+Rick Reynolds <reynoldr@mail.nih.gov> <rickr@manwe.nimh.nih.gov>
+Rick Reynolds <reynoldr@mail.nih.gov> <rickr@new-host-2.home>
+Robert Cox <robertcox@mail.nih.gov>
+Robert Cox <robertcox@mail.nih.gov> cox <>
+Robert Cox <robertcox@mail.nih.gov> rwcox <>
+Robert Cox <robertcox@mail.nih.gov> <rwcox123@gmail.com> 
+Robert Cox <robertcox@mail.nih.gov> <rwcox@mh02217089maclt.fios-router.home>
+Yaroslav Halchenko <debian@onerussian.com> 
+Yaroslav Halchenko <debian@onerussian.com> <site-github-private@onerussian.com>
+Yaroslav Halchenko <debian@onerussian.com> <yoh@smaug.cns.dartmouth.edu>
+Ziad S. Saad <saadz@mail.nih.gov>
+Ziad S. Saad <saadz@mail.nih.gov> ziad <>
+Ziad S. Saad <saadz@mail.nih.gov> ziad <ziad.ss@gmail.com>
+Ziad S. Saad <saadz@mail.nih.gov> <zsaad@its.jnj.com>
+Ziad S. Saad <saadz@mail.nih.gov> <zsaad@ITS.JNJ.com>


### PR DESCRIPTION
Compare master:

	$> git shortlog -sn | head -n 20
	  6007	rwcox
	  2803	rick reynolds
	  2378	ziad
	  2058	RWCox
	  1995	rickr
	  1675	mrneont
	   576	leej3
	   549	afniHQ
	   416	dglen
	   387	gangc
	   339	daniel glen
	   279	Ziad S. Saad
	   252	cox
	   244	Peter Lauren
	   170	Paul Taylor
	   160	gang chen
	   133	afni-gangc
	   121	discoraj
	   111	afni-rickr
		78	Daniel Glen

to this branch:

	$> git shortlog -sn | head -n 20
	  8352	Robert Cox
	  4985	Rick Reynolds
	  2711	Ziad S. Saad
	  1869	Paul Taylor
	   833	Daniel Glen
	   692	Gang Chen
	   592	John Lee
	   549	afniHQ
	   244	Peter Lauren
	   121	discoraj
		68	Nikolaas N. Oosterhof
		48	Paul Novak
		40	afni-discoraj
		38	Ubuntu
		37	rhammett
		36	Cameron Craddock
		36	shotgunosine
		34	Joshua Teves
		31	Jakub Kaczmarzyk
		28	Yaroslav Halchenko

PS believe me -- 20 was really an arbitrary cut off!!! ;)