### PR TITLE
circleci config: update xcode ver to 13.4.1 (older to be deprecated)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -419,7 +419,7 @@ jobs:
   macos_build:
     working_directory: /tmp/src/afni
     macos:
-        xcode: "12.4.0"
+        xcode: "13.4.1"
     steps: # a series of commands to run
       - checkout_afni
       - setup_macos_for_afni

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -420,7 +420,7 @@ jobs:
     working_directory: /tmp/src/afni
     macos:
         xcode: "13.4.1"
-    steps: # a series of commands to run 
+    steps: # a series of commands to run
       - checkout_afni
       - setup_macos_for_afni
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -420,7 +420,7 @@ jobs:
     working_directory: /tmp/src/afni
     macos:
         xcode: "13.4.1"
-    steps: # a series of commands to run
+    steps: # a series of commands to run 
       - checkout_afni
       - setup_macos_for_afni
       - run:


### PR DESCRIPTION
updating this, because I/we received an email that we had to, as older Xcode on CircleCI was being deprecated; info here:
https://circleci.com/docs/xcode-policy?mkt_tok=NDg1LVpNSC02MjYAAAGFttuqMW-YSbKpyZSrD6hMP3HDv5O_Aeox1Fa8EdVU4lD3yK6ef3aYkw7o0BJCvkvQWlDISYnucF-FzLkT7Q45k3Gu-lJxIQ1W_1JmnW1u-BvyiQ