### PR TITLE
Update @afni_R_package_install subscript for R versions > 4.0

### DIFF
--- a/src/shiny/misc/OmicCircos_pkg_install.R
+++ b/src/shiny/misc/OmicCircos_pkg_install.R
@@ -7,7 +7,11 @@
 ## get R version 
 r.ver <- R.Version()
 
-if(r.ver$minor >= 6){
+if(r.ver$major == 4) {
+	if (!require("BiocManager", quietly = TRUE))
+		install.packages("BiocManager",repos="https://cloud.r-project.org")
+	BiocManager::install("OmicCircos")
+} else if(r.ver$major == 3 & r.ver$minor >= 6){
 
   if (!requireNamespace("BiocManager",quietly=TRUE))
     install.packages("BiocManager",repos="https://cloud.r-project.org")

--- a/src/shiny/misc/OmicCircos_pkg_install.R
+++ b/src/shiny/misc/OmicCircos_pkg_install.R
@@ -3,6 +3,7 @@
 ## 11/2017 Justin Rajendra
 ## 10/2019 added devel version for R version >= 3.6
 ## 06/2020 remove devel for R version >= 3.6
+## 11/2022 add version 4 specific syntax
 
 ## get R version 
 r.ver <- R.Version()
@@ -11,12 +12,11 @@ if(r.ver$major == 4) {
 	if (!require("BiocManager", quietly = TRUE))
 		install.packages("BiocManager",repos="https://cloud.r-project.org")
 	BiocManager::install("OmicCircos")
+	
 } else if(r.ver$major == 3 & r.ver$minor >= 6){
-
   if (!requireNamespace("BiocManager",quietly=TRUE))
     install.packages("BiocManager",repos="https://cloud.r-project.org")
   
-  ## The following initializes usage of Bioc devel
   # BiocManager::install(version='devel',ask=FALSE)
   BiocManager::install("OmicCircos")
   


### PR DESCRIPTION
Fixes issues with installing Shiny packages in demo on R versions > 4. 

@discoraj does this look okay? 