### PR TITLE
Fix SUMA_INCLUDE_PATH for the universal Makefile

### DIFF
--- a/src/other_builds/Makefile.linux_ubuntu_22_64
+++ b/src/other_builds/Makefile.linux_ubuntu_22_64
@@ -131,7 +131,7 @@ LLIBS_X11 = -lmri -lf2c -lXm -lXpm -lXext -lXmu -lXt -lSM -lICE -lX11 \
 # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 # For suma (NO STATIC LINKING OF GL libs)
 SUMA_GLIB_VER = -2.0
-SUMA_INCLUDE_PATH = -I/usr/X11R6/include -I./ -I../ -I../niml/ -Igts/src -I/usr/include/glib-1.2 -I/usr/include/glib-2.0 -I/usr/lib64/glib/include -I/usr/lib64/ glib-2.0/include -I/usr/lib/x86_64-linux-gnu/glib-2.0/include/
+SUMA_INCLUDE_PATH = -I/usr/X11R6/include -I./ -I../ -I../niml/ -Igts/src -I/usr/include/glib-1.2 -I/usr/include/glib-2.0 -I/usr/lib64/glib/include -I/usr/lib64/ -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/lib/aarch64-linux-gnu/glib-2.0/include
 SUMA_LINK_PATH = -L/usr/lib64 -L/usr/X11R6/lib64 -L../
 #use -lGLw if you have libGLw.a or libGLw.so* or 
 #  -lMesaGLw if you have Mesa's version (libMesaGLw*) of libGLw


### PR DESCRIPTION
1) Remove wrong path - `glib-2.0/include`
2) Add include path for aarch64 - `-I/usr/lib/aarch64-linux-gnu/glib-2.0/include`


This is one of the changes suggested by @markjens at https://github.com/afni/afni/issues/390#issuecomment-1219148589. It seems it was never committed to the repository.