### PR TITLE
Powell NEWUOA 

### DIFF
--- a/src/python_scripts/scripts/align_epi_anat.py
+++ b/src/python_scripts/scripts/align_epi_anat.py
@@ -2957,11 +2957,12 @@ class RegWrap:
    def resample_epi(  self, e=None, resample_opt="", prefix="temp_rs", \
         subbrick=""):
       o = afni_name(prefix)
+      o.view = ps.anat_ns.view
+
       if (not o.exist() or ps.rewrite or ps.dry_run()):
          o.delete(ps.oexec)
          self.info_msg( "resampling %s to match %s data" % \
            (ps.dset2_generic_name, ps.dset1_generic_name ))
-
          if (subbrick == ""):
              sb = ""
          else:
@@ -2988,6 +2989,7 @@ class RegWrap:
       self.info_msg( "removing skull or area outside brain")
       if (use_ss == '3dSkullStrip'):     #skullstrip epi
          n = afni_name(prefix)
+         n.view = e.view
          if (not n.exist() or ps.rewrite or ps.dry_run()):
             n.delete(ps.oexec)
             com = shell_com(  \
@@ -3001,7 +3003,9 @@ class RegWrap:
             self.exists_msg(n.input())
       elif use_ss == '3dAutomask': #Automask epi
          n = afni_name(prefix)
+         n.view = e.view
          j = afni_name("%s__tt_am_%s" % (n.p(),n.pve()))
+
          if (not n.exist() or ps.rewrite or ps.dry_run()):
             n.delete(ps.oexec)
             com = shell_com(  \
@@ -3026,7 +3030,7 @@ class RegWrap:
    # box, bin and fat mask are not used
       a = ps.anat_ns
       
-      o = afni_name("%s%s%s%s" % (ps.output_dir,e.out_prefix(), suf,e.view))            
+      o = afni_name("%s%s%s%s" % (ps.output_dir,e.out_prefix(), suf,e.view))
       if perci < 0:
          perci = 90.0;
       self.info_msg( "Computing weight mask")

--- a/src/simplex.c
+++ b/src/simplex.c
@@ -845,7 +845,9 @@ void newuoa_optimization
      NEWUOA will operate on these, since it is scale-free */
 
   for( ii=0 ; ii < r+p ; ii++ ){
-    dv[ii] = (double) ((parameters[ii]-N_pbot[ii])/N_psiz[ii]);
+    if(N_psiz[ii] == 0.0) dv[ii] = 0.0;
+    else
+       dv[ii] = (double) ((parameters[ii]-N_pbot[ii])/N_psiz[ii]);
     if( dv[ii] < 0.0 || dv[ii] > 0.0 ) dv[ii] = DRED01(dv[ii]); /* 03 Nov 2006 */
   }
 


### PR DESCRIPTION
Powell NEWUOA would provide NaNs (not a number) if a constraint min=max  for any parameter. While not a typical use case, it can be a test case and was causing problems with a specific test.

align_epi_anat.py would fail on the resample step if the anat and EPI datasets (dset1,2) had different view space inputs - one was ORIG, the other TLRC (tlrc view) (MNI, waxrat, ... any non-ORIG space). The view is now set for the resample to match the master, the anatomical dataset. That view is also applied appropriately in the subsequent step for the  EPI skullstripping/automasking step too.