### PR TITLE
warn on trim error

### DIFF
--- a/src/afni_history_rickr.c
+++ b/src/afni_history_rickr.c
@@ -55,7 +55,7 @@ afni_history_struct rickr_history[] = {
 
  { 24, Jan, 2023, RCR, "3dvolreg", MINOR, TYPE_ENHANCE,
    "add error message for trimming weight set to empty",
-   "For now, still let it crash.  Try to trap in startup_lsqfit laster."
+   "For now, still let it crash.  Try to trap in startup_lsqfit later."
  } ,
 
  { 24, Jan, 2023, RCR, "afni_proc.py", MINOR, TYPE_ENHANCE,

--- a/src/afni_history_rickr.c
+++ b/src/afni_history_rickr.c
@@ -53,6 +53,11 @@
 
 afni_history_struct rickr_history[] = {
 
+ { 24, Jan, 2023, RCR, "3dvolreg", MINOR, TYPE_ENHANCE,
+   "add error message for trimming weight set to empty",
+   "For now, still let it crash.  Try to trap in startup_lsqfit laster."
+ } ,
+
  { 24, Jan, 2023, RCR, "afni_proc.py", MINOR, TYPE_ENHANCE,
    "add QC output to ricor block",
    NULL

--- a/src/thd_automask.c
+++ b/src/thd_automask.c
@@ -1577,6 +1577,14 @@ ENTRY("THD_autobbox") ;
 static int bbox_clust=1 ;
 void MRI_autobbox_clust( int c ){ bbox_clust = c; }
 
+
+/*---------------------------------------------------------------------*/
+/*! For each plane direction, return the first and last index that have
+ *  nonzero voxels in that plane.
+ *
+ *  If an early error, the last positions will be -1.
+ *  If the box is empty, the last positions will be -1.
+-----------------------------------------------------------------------*/
 void MRI_autobbox( MRI_IMAGE *qim ,
                    int *xm, int *xp , int *ym, int *yp , int *zm, int *zp )
 {


### PR DESCRIPTION
warn when trim (or other) sends weights to empty - ponder startup_lsqfit later