### PR TITLE
Changed CalcRanksForReHo to properly calculate ties at the end

### DIFF
--- a/src/ptaylor/rsfc.c
+++ b/src/ptaylor/rsfc.c
@@ -104,7 +104,7 @@ int CalcRanksForReHo(float *IND, int idx, THD_3dim_dataset *T, int *NTIE,
     else if( (sorted[m]==sorted[m-1]) && LENTIE>0 ) {
       LENTIE+= 1 ;
     }
-    else if( (sorted[m]!=sorted[m-1]) && LENTIE>0 ) {
+    if( ((sorted[m]!=sorted[m-1]) || (m == TDIM-1)) && LENTIE>0 ) {
       // end of tie: calc mean index
       TIERANK = 1.0*ISTIE; // where tie started
       TIERANK+= 0.5*(LENTIE-1); // make average rank


### PR DESCRIPTION
The CalcRanksForReHo function had a small edge case bug where the assigned ranks would not be adjusted for ties if these ties occurred at the end of the sorted time course. The value of LENTIE may be greater than 0 but sorted[m]!=sorted[m-1] will be false at the end of the loop. This code change will fix the issue.