### PR TITLE
Non ttatlas

### DIFF
--- a/src/AFNI_atlas_spaces.niml
+++ b/src/AFNI_atlas_spaces.niml
@@ -595,3 +595,107 @@
 ></TEMPLATE>
 
 #**********************************************
+<TEMPLATE_SPACE
+  space_name="MNI_2009c_asym"
+  generic_space="MNI"
+  comment="MNI 2009c asymmetric template 1mm3"
+></TEMPLATE_SPACE>
+
+<TEMPLATE_SPACE
+  space_name="MNI_N27"
+  generic_space="MNI"
+  comment="MNI N27 Single Subject"
+></TEMPLATE_SPACE>
+
+<ATLAS
+  atlas_name="FS.afni.MNI2009c_asym"
+  dset_name="FS.afni.MNI2009c_asym.nii.gz"
+  template_space="MNI_2009c_asym"
+  description="Freesurfer MNI2009c DK parcellation"
+  comment="Freesurfer recon-all freesurfer-linux-centos7_x86_64-7.3.2-20220804-6354275" />
+<ATLAS
+  atlas_name="FS.afni.TTN27"
+  dset_name="FS.afni.TTN27.nii.gz"
+  template_space="TT_N27"
+  description="Freesurfer TT_N27 DK parcellation"
+  comment="Freesurfer recon-all freesurfer-linux-centos7_x86_64-7.3.2-20220804-6354275" />
+></ATLAS>
+
+<ATLAS
+ atlas_name="Brodmann_Pijn"
+ dset_name="Brodmann.nii.gz"
+ template_space="MNI_N27"
+ description="Brodmann atlas MNI N27 - Pijnenburg"
+ comment="Pijnenburg, R., et al (2021). Myelo- and cytoarchitectonic microstructural and functional human cortical atlases reconstructed in common MRI space. NeuroImage, 239, 118274."
+></ATLAS>
+
+<ATLAS
+ atlas_name="Brodmann_Pijn_AFNI"
+ dset_name="Brodmann_pijn_afni.nii.gz"
+ template_space="MNI_2009c_asym"
+ description="Brodmann atlas for MNI 2009c - Pijnenburg AFNI version"
+ comment="Pijnenburg, R., et al (2021). Myelo- and cytoarchitectonic microstructural
+     and functional human cortical atlases reconstructed in common MRI space.
+     NeuroImage, 239, 118274.
+     This AFNI version has been reprojected into the MNI 2009c template space 
+     via a standard mesh surface and then modally smoothed and renumbered."
+></ATLAS>
+
+<ATLAS
+  atlas_name="Julich_MNI2009c"
+  dset_name="Julich_MNI2009c.nii.gz"
+  template_space="MNI_2009c_asym"
+  description="JulichBrain 3.0 for MNI 2009c asymmetric space"
+  comment="From EBRAINS3.0 website, v3.0.3 available here:
+    https://search.kg.ebrains.eu/instances/d69b70e2-3002-4eaf-9c61-9c56f019bbc8
+
+    Please cite this dataset version and the original research publication:
+    Amunts, K, Mohlberg, H, Bludau, S, Caspers, S, Lewis, LB, Eickhoff, SB, 
+      Pieperhoff, P (2023). 
+      Julich-Brain Atlas, cytoarchitectonic maps (v3.0.3) [Data set].
+      DOI: 10.25493/56EM-75H
+    Evans, AC, Janke, AL, Collins, DL, Baillet, S (2012).
+      Brain templates and atlases. NeuroImage, 62(2), 911–922.
+      DOI: 10.1016/j.neuroimage.2012.01.024
+    Eickhoff, SB, Stephan, KE, Mohlberg, H, Grefkes, C, Fink, GR, Amunts, K,
+      Zilles, K. (2005).
+      A new SPM toolbox for combining probabilistic cytoarchitectonic maps and
+      functional imaging data. NeuroImage, 25(4), 1325–1335.
+      DOI: 10.1016/j.neuroimage.2004.12.034
+
+    For the overall scientific concept and methodology of the Julich-Brain, please cite:
+      Amunts, K, Mohlberg, H, Bludau, S, & Zilles, K (2020).
+      Julich-Brain: A 3D probabilistic atlas of the human brain’s cytoarchitecture.
+      Science, 369(6506), 988–992.
+      DOI: 10.1126/science.abb4588
+"
+></ATLAS>
+
+<ATLAS
+  atlas_name="Julich_MNI_N27"
+  dset_name="Julich_MNI_N27.nii.gz"
+  template_space="MNI_N27"
+  description="JulichBrain 3.0 for MNI N27 space"
+  comment="From EBRAINS3.0 website, v3.0.3 avaialble here:
+    https://search.kg.ebrains.eu/instances/d69b70e2-3002-4eaf-9c61-9c56f019bbc8
+
+    Please cite this dataset version and the original research publication:
+    Amunts, K, Mohlberg, H, Bludau, S, Caspers, S, Lewis, LB, Eickhoff, SB, 
+      Pieperhoff, P (2023). 
+      Julich-Brain Atlas, cytoarchitectonic maps (v3.0.3) [Data set].
+      DOI: 10.25493/56EM-75H
+    Evans, AC, Janke, AL, Collins, DL, Baillet, S (2012).
+      Brain templates and atlases. NeuroImage, 62(2), 911–922.
+      DOI: 10.1016/j.neuroimage.2012.01.024
+    Eickhoff, SB, Stephan, KE, Mohlberg, H, Grefkes, C, Fink, GR, Amunts, K,
+      Zilles, K. (2005).
+      A new SPM toolbox for combining probabilistic cytoarchitectonic maps and
+      functional imaging data. NeuroImage, 25(4), 1325–1335.
+      DOI: 10.1016/j.neuroimage.2004.12.034
+
+    For the overall scientific concept and methodology of the Julich-Brain, please cite:
+      Amunts, K, Mohlberg, H, Bludau, S, & Zilles, K (2020).
+      Julich-Brain: A 3D probabilistic atlas of the human brain’s cytoarchitecture.
+      Science, 369(6506), 988–992.
+      DOI: 10.1126/science.abb4588
+></ATLAS>

--- a/src/AFNI_atlas_spaces.niml
+++ b/src/AFNI_atlas_spaces.niml
@@ -674,7 +674,7 @@
 <ATLAS
   atlas_name="Julich_MNI_N27"
   dset_name="Julich_MNI_N27.nii.gz"
-  template_space="MNI_N27"
+  template_space="MNI"
   description="JulichBrain 3.0 for MNI N27 space"
   comment="From EBRAINS3.0 website, v3.0.3 avaialble here:
     https://search.kg.ebrains.eu/instances/d69b70e2-3002-4eaf-9c61-9c56f019bbc8
@@ -699,3 +699,26 @@
       Science, 369(6506), 988–992.
       DOI: 10.1126/science.abb4588
 ></ATLAS>
+
+<XFORM
+  ni_type="1*float"
+  ni_dimen="1"
+  xform_name="MNI::MNI_N27"
+  source="MNI"
+  dest="MNI_N27"
+  distance="0.1"
+  xform_type="Identity" >
+  1
+>
+</XFORM>
+<XFORM
+  ni_type="1*float"
+  ni_dimen="1"
+  xform_name="MNI::MNI_2009c_asym"
+  source="MNI"
+  dest="MNI_2009c_asym"
+  distance="0.1"
+  xform_type="Identity" >
+  1
+>
+</XFORM>

--- a/src/AFNI_atlas_spaces.niml
+++ b/src/AFNI_atlas_spaces.niml
@@ -382,7 +382,7 @@
 <ATLAS
  atlas_name="MNI_Glasser_HCP_v1.0"
  dset_name="MNI_Glasser_HCP_v1.0.nii.gz"
- template_space="MNI"
+ template_space="MNI_2009c_asym"
  description="Glasser HCP 2016 surface-based parcellation"
  comment="Glasser, et al,A multi-modal parcellation of human cerebral cortex,
     Nature,2016. 
@@ -400,7 +400,8 @@
  description="Brainnetome MPM"
  comment="Please cite Fan, L. et al., The Human Brainnetome Atlas:
      A New Brain Atlas Based on Connectional Architecture.
-     Cerebral Cortex, 26 (8): 3508-3526,(2016)."
+     Cerebral Cortex, 26 (8): 3508-3526,(2016).
+     In HCP-40 space, a space similar to MNI_2009c"
 ></ATLAS>
 
 <ATLAS
@@ -442,6 +443,7 @@
        Frontal pole (Fp1, Fp2)----------------------------------------- Bludau et al., Neuroimage, 2014
    Other areas may only be used with authors' permission !
 
+   Template space likely to be MNI_N27 space 
    AFNI adaptation by
     Ziad S. Saad and Daniel Glen (SSCC/NIMH/NIH)"
 ></ATLAS>
@@ -508,7 +510,7 @@
 <ATLAS
    atlas_name="CA_ML_18_MNI"   
    dset_name="MNI_caez_ml_18+tlrc"
-   template_space="MNI"
+   template_space="MNI_N27"
    description="Macro Labels (N27-MNI)"
    comment="Eickhoff-Zilles macro labels from N27 (MNI space)"
 ></ATLAS>
@@ -516,7 +518,7 @@
 <ATLAS
    atlas_name="CA_LR_18_MNI"
    dset_name="MNI_caez_lr_18+tlrc"
-   template_space="MNI"
+   template_space="MNI_N27"
    description="Left/Right (N27-MNI)"
    comment="Simple left, right hemisphere segmentation (MNI space)"
 ></ATLAS>
@@ -674,9 +676,9 @@
 <ATLAS
   atlas_name="Julich_MNI_N27"
   dset_name="Julich_MNI_N27.nii.gz"
-  template_space="MNI"
+  template_space="MNI_N27"
   description="JulichBrain 3.0 for MNI N27 space"
-  comment="From EBRAINS3.0 website, v3.0.3 avaialble here:
+  comment="From EBRAINS3.0 website, v3.0.3 available here:
     https://search.kg.ebrains.eu/instances/d69b70e2-3002-4eaf-9c61-9c56f019bbc8
 
     Please cite this dataset version and the original research publication:

--- a/src/AFNI_atlas_spaces.niml
+++ b/src/AFNI_atlas_spaces.niml
@@ -494,23 +494,6 @@
     Ziad S. Saad and Daniel Glen (SSCC/NIMH/NIH)"
 ></ATLAS>
 
-<ATLAS
-   atlas_name="CA_N27_MPM"   
-   dset_name="TT_caez_mpm_18+tlrc"
-   template_space="TT_N27"
-   description="Cytoarch. Max. Prob. Maps"
-   comment="Eickhoff-Zilles maximum probability map-1.8 version on TT_N27
-    from post-mortem analysis"
-></ATLAS>
-
-<ATLAS
-   atlas_name="CA_N27_PM"   
-   dset_name="TT_caez_pmaps_18+tlrc"
-   template_space="TT_N27"
-   description="Cytoarch. Probabilistic Maps 1.8"
-   comment="Eickhoff-Zilles probability maps 1.8 version on TT_N27
-    from post-mortem analysis"
-></ATLAS>
 
 <ATLAS
    atlas_name="CA_N27_GW"   
@@ -519,14 +502,6 @@
    description="Cytoarch. Prob. Maps for gray/white matter 1.8"
    comment="Eickhoff-Zilles probability maps on MNI-152 1.8 version
     from post-mortem analysis"
-></ATLAS>
-
-<ATLAS
-   atlas_name="CA_N27_LR"
-   dset_name="TT_caez_lr_18+tlrc"
-   template_space="TT_N27"
-   description="Left/Right (N27) 1.8"
-   comment="Simple left, right hemisphere segmentation 1.8 version"
 ></ATLAS>
 
 #Cytoarchitectonic atlases shifted to MNI space
@@ -539,15 +514,6 @@
 ></ATLAS>
 
 <ATLAS
-   atlas_name="CA_MPM_18_MNI"   
-   dset_name="MNI_caez_mpm_18+tlrc"
-   template_space="MNI"
-   description="Cytoarch. Max. Prob. Maps (MNI)"
-   comment="Eickhoff-Zilles maximum probability map on MNI-152 
-     from post-mortem analysis (MNI space)"
-></ATLAS>
-
-<ATLAS
    atlas_name="CA_LR_18_MNI"
    dset_name="MNI_caez_lr_18+tlrc"
    template_space="MNI"
@@ -555,114 +521,6 @@
    comment="Simple left, right hemisphere segmentation (MNI space)"
 ></ATLAS>
 
-
-#Cytoarchitectonic atlases in original MNI_ANAT space
-<ATLAS
-   atlas_name="CA_ML_18_MNIA"   
-   dset_name="MNIa_caez_ml_18+tlrc"
-   template_space="MNI_ANAT"
-   description="Macro Labels (N27)"
-   comment="Eickhoff-Zilles macro labels from N27 (MNI_ANAT space)"
-></ATLAS>
-
-<ATLAS
-   atlas_name="CA_MPM_18_MNIA"   
-   dset_name="MNIa_caez_mpm_18+tlrc"
-   template_space="MNI_ANAT"
-   description="Cytoarch. Max. Prob. Maps"
-   comment="Eickhoff-Zilles maximum probability map on MNI-152 from post-mortem analysis (MNI_ANAT space)"
-></ATLAS>
-
-<ATLAS
-   atlas_name="CA_PM_18_MNIA"   
-   dset_name="MNIa_caez_pmaps_18+tlrc"
-   template_space="MNI_ANAT"
-   description="Cytoarch. Probabilistic Maps"
-   comment="Eickhoff-Zilles probability maps on MNI-152 from post-mortem analysis (MNI_ANAT space)"
-></ATLAS>
-
-<ATLAS
-   atlas_name="CA_GW_18_MNIA"   
-   dset_name="MNIa_caez_gw_18+tlrc"
-   template_space="MNI_ANAT"
-   description="Cytoarch. Prob. Maps for gray/white matter"
-   comment="Eickhoff-Zilles probability maps on MNI-152 from post-mortem analysis (MNI_ANAT space)"
-></ATLAS>
-
-<ATLAS
-   atlas_name="CA_LR_18_MNIA"
-   dset_name="MNIa_caez_lr_18+tlrc"
-   template_space="MNI_ANAT"
-   description="Left/Right (N27)"
-   comment="Simple left, right hemisphere segmentation (MNI_ANAT space)"
-></ATLAS>
-
-
-#Desai atlases - based on @auto_tlrc alignment of FreeSurfer parcellation
-<ATLAS
-   atlas_name="DKD_Desai_PM"
-   dset_name="TT_desai_dkpmaps+tlrc"
-   template_space="TT_N27"
-   description="Probability maps of 35 cortical areas (gyri)"
-   comment="
-     Please cite:
-     Desikan et al., Neuroimage 2006 (31) pp. 968-980."
-></ATLAS>
-
-<ATLAS
-   atlas_name="DD_Desai_PM"
-   dset_name="TT_desai_ddpmaps+tlrc"
-   template_space="TT_N27"
-   description="Probability maps of 75 cortical areas"
-   comment="
-     For each hemisphere,including both gyri and sulci.
-     Please cite:
-       Destrieux et al., Neuroimage 2010 (53) pp. 1-15."
-></ATLAS>
-
-<ATLAS
-   atlas_name="FS_Desai_PM"
-   dset_name="TT_desai_fspmaps+tlrc"
-   template_space="TT_N27"
-   description="40 subcortical areas"
-   comment="15 in left & right hemispheres,10 midline structures parcellated by freesurfer"
-></ATLAS>
-
-<ATLAS
-   atlas_name="DD_Desai_MPM"
-   dset_name="TT_desai_dd_mpm+tlrc"
-   template_space="TT_N27"
-   description="Maximum probability maps of Desai DD and FS maps"
-   comment="Smoothed maximum maps masked by unsmoothed maximum map"
-></ATLAS>
-
-<ATLAS
-   atlas_name="DKD_Desai_MPM"
-   dset_name="TT_desai_dk_mpm+tlrc"
-   template_space="TT_N27"
-   description="Maximum probability maps of Desai DKD and FS maps"
-   comment="Smoothed maximum maps masked by unsmoothed maximum map"
-></ATLAS>
-
-# Ventromedial prefrontal cortex
-<ATLAS
- atlas_name="MNI_VmPFC"
- dset_name="MNI_VmPFC+tlrc"
- template_space="MNI"
- description="Ventromedial Prefrontal Cortex"
- comment="Mackey, S. and Petrides, M. (2014), Architecture and morphology
-     of the human ventromedial prefrontal cortex. European Journal 
-     of Neuroscience, 40: 2777-796. doi: 10.1111/ejn.12654"
-></ATLAS>
-
-# Classic and deeply flawed Talairach Daemon (moved down to avoid being shown early in whereami output)
-<ATLAS
-   atlas_name="TT_Daemon"   
-   dset_name="TTatlas+tlrc"
-   template_space="TLRC"
-   description="Talairach-Tournoux Atlas"
-   comment="The standard talaraich atlas"
-></ATLAS>
 
 # Haskins Pediatric atlas (nonlinear version only)
 <ATLAS
@@ -697,43 +555,6 @@
 ></TEMPLATE>
 
 <TEMPLATE
-   template_name="TT_152_2009c+tlrc"
-   template_space="TT_N27"
-   comment="Talairached MNI 2009c template, aligned to TT_N27
-      with @auto_tlrc. See MNI152_T1_2009c+tlrc for copyright
-      and citation information"
-></TEMPLATE>
-
-<TEMPLATE
-   template_name="TT_avg152T1+tlrc"
-   template_space="TT_avg"
-   comment="152 subjects T1 scan aligned to Colin brain template.
-     Brett transformed to TLRC"
-></TEMPLATE>
-
-<TEMPLATE
-   template_name="TT_avg152T2+tlrc"
-   template_space="TT_avg"
-   comment="152 subjects T2 scan aligned to Colin brain template
-     Brett transformed to TLRC"
-></TEMPLATE>
-
-<TEMPLATE
-   template_name="TT_icbm452+tlrc"
-   template_space="TT_avg"
-   comment="452 subjects T1 scan aligned to Colin brain template
-    This dataset was manually transformed to Talairach space from
-    an Analyze format dataset from the ICBM/LONI site"
-></TEMPLATE>
-
-<TEMPLATE
-   template_name="TT_EPI+tlrc"
-   template_space="TT_avg"
-   comment="EPI average template
-    Brett transformed to TLRC"
-></TEMPLATE>
-
-<TEMPLATE
    template_name="MNI152_T1_2009c+tlrc"
    template_space="MNI"
    comment="152 subjects T1 nonlinear at 1mm
@@ -756,26 +577,6 @@
       authors are not responsible for any data loss, equipment damage,
       property loss, or injury to subjects or patients resulting from the use
       or misuse of this software package."
-></TEMPLATE>
-
-<TEMPLATE
-   template_name="MNI152.nii"
-   template_space="MNI"
-></TEMPLATE>
-
-<TEMPLATE
-   template_name="ICBM452.nii"
-   template_space="MNI"
-></TEMPLATE>
-
-<TEMPLATE
-   template_name="MNI_EPI.nii"
-   template_space="MNI"
-></TEMPLATE>
-
-<TEMPLATE
-   template_name="MNIa_caez_N27+tlrc"
-   template_space="MNI_ANAT"
 ></TEMPLATE>
 
 <TEMPLATE

--- a/src/AFNI_atlas_spaces.niml
+++ b/src/AFNI_atlas_spaces.niml
@@ -407,7 +407,7 @@
 <ATLAS
   atlas_name="CA_MPM_22_MNI"
   dset_name="MNI_caez_mpm_22+tlrc"
-  template_space="MNI"
+  template_space="MNI_N27"
   description="Eickhoff-Zilles MPM atlas"
   comment="Eickhoff-Zilles maximum probability map from cytoarchitectonic probabilistic atlas
    SPM ANATOMY TOOLBOX  v2.2
@@ -443,7 +443,6 @@
        Frontal pole (Fp1, Fp2)----------------------------------------- Bludau et al., Neuroimage, 2014
    Other areas may only be used with authors' permission !
 
-   Template space likely to be MNI_N27 space 
    AFNI adaptation by
     Ziad S. Saad and Daniel Glen (SSCC/NIMH/NIH)"
 ></ATLAS>
@@ -558,7 +557,7 @@
 
 <TEMPLATE
    template_name="MNI152_T1_2009c+tlrc"
-   template_space="MNI"
+   template_space="MNI_2009c_asym"
    comment="152 subjects T1 nonlinear at 1mm
       VS Fonov, et al, Unbiased average age-appropriate atlases for pediatric
       studies,NeuroImage,Volume 54, Issue 1, January 2011, ISSN 1053-8119,
@@ -583,7 +582,7 @@
 
 <TEMPLATE
    template_name="MNI_caez_N27+tlrc"
-   template_space="MNI"
+   template_space="MNI_N27"
 ></TEMPLATE>
 
 <TEMPLATE

--- a/src/afni_widg.c
+++ b/src/afni_widg.c
@@ -1017,7 +1017,8 @@ STATUS("making imag->rowcol") ;
             NULL ) ;
       XtAddCallback( imag->pop_talto_pb , XmNactivateCallback ,
                      AFNI_imag_pop_CB , im3d ) ;
-      if( TT_retrieve_atlas_dset("TT_Daemon",0) ){
+//      if( TT_retrieve_atlas_dset("TT_Daemon",0) ){
+      if( TT_retrieve_atlas_dset(Current_Atlas_Default_Name(),0) ) {
          imag->pop_whereami_pb =        /* 10 Jul 2001 */
             XtVaCreateManagedWidget(
                "dialog" , xmPushButtonWidgetClass , imag->popmenu ,
@@ -1046,8 +1047,9 @@ STATUS("making imag->rowcol") ;
         if( first ){
           first = 0 ;
           fprintf(stderr,
-           "\n++ WARNING: Can't find TTatlas+tlrc or TTatlas.nii.gz dataset for 'whereami'!\n"
-             "++--------- See https://afni.nimh.nih.gov/pub/dist/data/\n" ) ;
+        "\n++ WARNING: Can't find default atlas (%s) dataset for 'whereami'!\n"
+        "++--------- See https://afni.nimh.nih.gov/pub/dist/data/\n",
+        Current_Atlas_Default_Name() ) ;
         }
       }
       imag->pop_whereami_twin = NULL ;

--- a/src/thd_ttatlas_query.c
+++ b/src/thd_ttatlas_query.c
@@ -68,8 +68,7 @@ THD_string_array *get_working_atlas_name_list(void) {
 	  "MNI_Glasser_HCP_v1.0","Brainnetome_1.0",
 	  "CA_ML_18_MNI", "CA_MPM_22_MNI",
       "DD_Desai_MPM", "DKD_Desai_MPM",
-      "CA_GW_18_MNIA", "CA_N27_LR",
-      "TT_Daemon", NULL};
+      "CA_GW_18_MNIA", "CA_N27_LR", NULL};
    int i;
 
    if (!working_atlas_name_list || working_atlas_name_list->num==0) {
@@ -7963,7 +7962,7 @@ int whereami_3rdBase( ATLAS_COORD aci, ATLAS_QUERY **wamip,
       if(ATL_WEB_TYPE(atlas) && (get_wami_web_reqtype() != WAMI_WEB_STRUCT)){
          if (wami_verb() > 1)
             INFO_message("trying to access web-based atlas");
-         elsevier_query_request(xout, yout, zout, atlas, get_wami_web_reqtype());
+//         elsevier_query_request(xout, yout, zout, atlas, get_wami_web_reqtype());
       }
       else{  /* regular (non-web) atlas request for local dataset */
          XYZ_to_AtlasCoord(xout, yout, zout, "RAI", atlas->space, &ac);
@@ -9232,7 +9231,6 @@ int AFNI_get_dset_label_ival(THD_3dim_dataset *dset, int *val, char *str)
 {
    ATR_string * atr=NULL;
    char       * str_lab=NULL;
-   int          found;
 
    ENTRY("AFNI_get_dset_label_ival") ;
 
@@ -9242,7 +9240,6 @@ int AFNI_get_dset_label_ival(THD_3dim_dataset *dset, int *val, char *str)
    }
 
    *val = 0;
-   found = 0;
 
    /* initialize hash table */
    if (!dset->Label_Dtable &&
@@ -9342,6 +9339,7 @@ int known_atlas_label_to_int_list(int_list * ilist, char * str)
 }
 
 
+#if 0
 /* open Elsevier's BrainNavigator in webpage */
 /* xyz input should be in RAI in the same space as atlas,
    but BrainNavigator takes "RSA" as xyz order, so coords need
@@ -9476,9 +9474,13 @@ elsevier_query_request(float xx, float yy, float zz, ATLAS *atlas, int el_req_ty
 
    RETURN(sss);
 }
+#endif
 
-
-/* query Elsevier for whereami at select locations */
+/* query Elsevier for whereami at select locations
+ * NOTE Elsevier does not provide this functionality
+*  so this code only provides a placeholder for similar web-based
+*  atlases, i.e. web servers that given an x y z location and an atlas
+*  name can provide an ROI label */
 void
 wami_query_web(ATLAS *atlas, ATLAS_COORD ac, ATLAS_QUERY *wami)
 {
@@ -9491,7 +9493,9 @@ wami_query_web(ATLAS *atlas, ATLAS_COORD ac, ATLAS_QUERY *wami)
       WAMIRAD = Init_Whereami_Max_Rad();
    }
 
-   blab = elsevier_query_request(ac.x, ac.y, ac.z, atlas, WAMI_WEB_STRUCT);
+// removing actual call to send request to defunct server
+//   blab = elsevier_query_request(ac.x, ac.y, ac.z, atlas, WAMI_WEB_STRUCT);
+   blab = NULL;
    if(blab == NULL)
        EXRETURN;
 

--- a/src/thd_ttatlas_query.c
+++ b/src/thd_ttatlas_query.c
@@ -61,8 +61,7 @@ THD_string_array *recreate_working_atlas_name_list(void) {
    return(get_working_atlas_name_list());
 }
 
-/* moved TT_Daemon down the road to the end and switched
- *  some Eickhoff-Zilles atlases to the MNI version instead of MNI_ANAT */
+/* almost complete change of default list*/
 THD_string_array *get_working_atlas_name_list(void) {
    char *min_atlas_list[] = {
 	  "Brodmann_Pijn_AFNI","MNI_Glasser_HCP_v1.0",
@@ -9092,7 +9091,7 @@ char *Current_Atlas_Default_Name()
    if(ept != NULL) return(search_quotes(ept)); /* remove any extra quotes*/
    if( ept != NULL ) return( ept ) ;
 
-   return("CA_ML_18_MNI"); // was TT_daemon - maybe set to Brodmann_Pijn_AFNI 
+   return("Brodmann_Pijn_AFNI"); // was TT_daemon - maybe set to Brodmann_Pijn_AFNI 
 
 }
 

--- a/src/thd_ttatlas_query.c
+++ b/src/thd_ttatlas_query.c
@@ -65,10 +65,11 @@ THD_string_array *recreate_working_atlas_name_list(void) {
  *  some Eickhoff-Zilles atlases to the MNI version instead of MNI_ANAT */
 THD_string_array *get_working_atlas_name_list(void) {
    char *min_atlas_list[] = {
-	  "MNI_Glasser_HCP_v1.0","Brainnetome_1.0",
-	  "CA_ML_18_MNI", "CA_MPM_22_MNI",
-      "DD_Desai_MPM", "DKD_Desai_MPM",
-      "CA_GW_18_MNIA", "CA_N27_LR", NULL};
+	  "Brodmann_Pijn_AFNI","MNI_Glasser_HCP_v1.0",
+      "FS.afni.MNI2009c_asym","FS.afni.TTN27",
+      "Julich_MNI2009c","Julich_MNI_N27",
+      "Brainnetome_1.0",
+	  "CA_ML_18_MNI", NULL};
    int i;
 
    if (!working_atlas_name_list || working_atlas_name_list->num==0) {
@@ -831,15 +832,25 @@ void TT_purge_atlas_big_old(void)
 /*! are we on the left or right of Colin? */
 char MNI_Anatomical_Side(ATLAS_COORD ac, ATLAS_LIST *atlas_list)
 {
+#if 0
    THD_ivec3 ijk ;
    THD_fvec3 mmxyz ;
    int  ix,jy,kz , nx,ny,nxy, ii=0, kk=0;
    byte *ba=NULL;
    static int n_warn = 0, lr_notfound = 0;
    ATLAS *atlas=NULL;
-
+#endif
    ENTRY("MNI_Anatomical_Side");
 
+// abandoning N27_LR mask method- no need for LR atlas in list
+// coordinates themselve determine left and right of brain
+      if (ac.x<0.0) {
+         RETURN('r');
+      } else {
+         RETURN('l');
+      }
+
+#if 0
    if(lr_notfound)
       RETURN('u');   /* tried to find LR atlas before but failed */
 
@@ -895,6 +906,7 @@ char MNI_Anatomical_Side(ATLAS_COORD ac, ATLAS_LIST *atlas_list)
 
    /* should not get here */
    RETURN('u');
+#endif
 }
 
 /*! What side are we on ?*/
@@ -1079,16 +1091,17 @@ char * genx_Atlas_Query_to_String (ATLAS_QUERY *wami,
       sprintf(y_fstr, "%s", format_value_4print(-acl[i].y, CCALC_CUSTOM, pf));
       sprintf(z_fstr, "%s", format_value_4print(acl[i].z, CCALC_CUSTOM, pf));
 
+    /* abandoning LR determination based on LR mask atlas - just using coords */
       /* the current rendition of this determines L/R from the CA_N27_LR
          brain in TLRC space based on the mask dataset with values of 0,1,2 */
       /* drg - see notes on MNI_Anatomical_Side at function for discussion */
 
-      if(strcmp(acl[i].space_name,"MNI_ANAT") || (it<0)) {
+//      if(strcmp(acl[i].space_name,"MNI_ANAT") || (it<0)) {
          sprintf(xlab[i],"%s mm [%c]", x_fstr, (acl[i].x<0.0)?'R':'L') ;
-      } else {
-         sprintf(xlab[i], "%s mm [%c]", x_fstr,
-           TO_UPPER(MNI_Anatomical_Side(acl[it], atlas_list))) ;
-      }
+//      } else {
+//         sprintf(xlab[i], "%s mm [%c]", x_fstr,
+//           TO_UPPER(MNI_Anatomical_Side(acl[it], atlas_list))) ;
+//      }
 
       sprintf(ylab[i],"%s mm [%c]",y_fstr,(acl[i].y<0.0)?'A':'P') ;
       sprintf(zlab[i],"%s mm [%c]",z_fstr,(acl[i].z<0.0)?'I':'S') ;
@@ -1811,12 +1824,12 @@ char * Atlas_Query_to_String (ATLAS_QUERY *wami,
       already in TLRC space. This LR volume had been converted from MNI_Anat space.
       The L/R volume is from a particular subject, and it is not completely aligned along
       any zero line separating left from right */
-      if(i!=MNI_ANAT_SPC)
+//      if(i!=MNI_ANAT_SPC)
          sprintf(xlab[i-1],"%4.0f mm [%c]",-acv[i].x,(acv[i].x<0.0)?'R':'L') ;
-      else
-         sprintf(xlab[i-1], "%4.0f mm [%c]",
-                   -acv[i].x, TO_UPPER(MNI_Anatomical_Side(acv[AFNI_TLRC_SPC],
-                               atlas_list))) ;
+//      else
+//         sprintf(xlab[i-1], "%4.0f mm [%c]",
+//                  -acv[i].x, TO_UPPER(MNI_Anatomical_Side(acv[AFNI_TLRC_SPC],
+//                               atlas_list))) ;
       sprintf(ylab[i-1],"%4.0f mm [%c]",-acv[i].y,(acv[i].y<0.0)?'A':'P') ;
       sprintf(zlab[i-1],"%4.0f mm [%c]", acv[i].z,(acv[i].z<0.0)?'I':'S') ;
       sprintf(clab[i-1],"{%s}", Space_Code_to_Space_Name(i));
@@ -7143,6 +7156,9 @@ ATLAS *Atlas_With_Trimming(char *atname, int LoadLRMask,
       /* check to see if dataset has to be distinguished
          left-right based on LR atlas */
       if (atlas->adh->build_lr && LoadLRMask) {
+         // abandoning LR mask determination for L/R coords 
+         lr_notfound = 1;
+#if 0
             /* DO NOT ask Atlas_With_Trimming to load LRMask in next call !! */
          atlas_lr = NULL;
          if(lr_notfound==0)
@@ -7161,6 +7177,8 @@ ATLAS *Atlas_With_Trimming(char *atname, int LoadLRMask,
                              "Proceeding without LR mask");
             }
          }
+#endif
+
       }
 
       atlas->adh->params_set = 1;   /* mark as initialized */

--- a/src/thd_ttatlas_query.c
+++ b/src/thd_ttatlas_query.c
@@ -1048,7 +1048,8 @@ char * genx_Atlas_Query_to_String (ATLAS_QUERY *wami,
       /* the classic three. */
       out_spaces =  add_to_names_list(out_spaces, &N_out_spaces, "TLRC");
       out_spaces =  add_to_names_list(out_spaces, &N_out_spaces, "MNI");
-      out_spaces =  add_to_names_list(out_spaces, &N_out_spaces, "MNI_ANAT");
+// no need for MNI_ANAT if none of the atlases are in that space
+//      out_spaces =  add_to_names_list(out_spaces, &N_out_spaces, "MNI_ANAT");
    }
 
    out_spaces = add_to_names_list(out_spaces, &N_out_spaces, ac.space_name);

--- a/src/thd_ttatlas_query.c
+++ b/src/thd_ttatlas_query.c
@@ -2102,7 +2102,7 @@ int XYZ_to_AtlasCoord(float x, float y, float z, char *orcode,
    if (spacename && spacename[0] != '\0') {
       set_Coord_Space_Name(ac, spacename);
    } else {
-      set_Coord_Space_Name(ac, "TT_Daemon");
+      set_Coord_Space_Name(ac, Current_Atlas_Default_Name());
    }
 
    return(1);
@@ -3557,7 +3557,7 @@ AFNI_ATLAS *Build_Atlas (char *aname, ATLAS_LIST *atlas_list)
       ERROR_message("Failed to get %s", aname);
       RETURN(NULL);
    }
-   /* Call this function just to force TT_Daemon to end up in BIG format*/
+   /* Call this function just to force default to end up in BIG format*/
    TT_retrieve_atlas_dset(aname, 1);
 
    if (LocalHead) fprintf(stderr,"%s loaded\n", aname);
@@ -9075,7 +9075,8 @@ char *Current_Atlas_Default_Name()
    if(ept != NULL) return(search_quotes(ept)); /* remove any extra quotes*/
    if( ept != NULL ) return( ept ) ;
 
-   return("TT_Daemon");
+   return("CA_ML_18_MNI"); // was TT_daemon - maybe set to Brodmann_Pijn_AFNI 
+
 }
 
 

--- a/src/thd_ttatlas_query.h
+++ b/src/thd_ttatlas_query.h
@@ -504,9 +504,9 @@ int AFNI_get_dset_label_ival(THD_3dim_dataset *dset, int *val, char *str);   /* 
 int thd_LT_label_to_int_list(THD_3dim_dataset *dset,int_list *ilist,char *str); /* 22 Nov 2016 [rickr] */
 int known_atlas_label_to_int_list(int_list * ilist, char * str);
 
-
-char *elsevier_query(float xx, float yy, float zz, ATLAS *atlas);
-char *elsevier_query_request(float xx, float yy, float zz, ATLAS *atlas, int el_req_type);
+// long defunct Elsevier server - code if 0'd if we need similar functionality
+// char *elsevier_query(float xx, float yy, float zz, ATLAS *atlas);
+// char *elsevier_query_request(float xx, float yy, float zz, ATLAS *atlas, int el_req_type);
 void wami_query_web(ATLAS *atlas, ATLAS_COORD ac, ATLAS_QUERY *wami);
 
 char * whereami_XML_get(char *data, char *name, char **next);


### PR DESCRIPTION
Fairly large list of changes to atlases and templates. Code changes for default atlases to use for Atlas colors and Go to atlas location and for default lists of atlases to search and default list of spaces to show in whereami.
Atlases and templates get a refresh/overhaul in AFNI_template_spaces.niml in the source.
Note this PR should be implemented simultaneously with atlas and template changes.
Seed-based correlations against the new specific MNI_2009c_asym, MNI_N27 will need to be allowed in afni_proc.py QC.