### PR TITLE
@chauffeur_afni func_resample logic error

### DIFF
--- a/src/scripts_install/@chauffeur_afni
+++ b/src/scripts_install/@chauffeur_afni
@@ -689,9 +689,9 @@ while ( $ac <= $#argv )
         if ( $ac >= $#argv ) goto FAIL_MISSING_ARG
         @ ac += 1
         set func_resam = "$argv[$ac]"
-        if ( ( "$func_resam" != "NN" ) || \
-             ( "$func_resam" != "Li" ) || \
-             ( "$func_resam" != "Cu" ) || \
+        if ( ( "$func_resam" != "NN" ) && \
+             ( "$func_resam" != "Li" ) && \
+             ( "$func_resam" != "Cu" ) && \
              ( "$func_resam" != "Bk" ) ) then
             echo "** ERROR: '-func_resam ...' input"
             echo "   needs to be one of {NN|Li|Cu|Bk}."


### PR DESCRIPTION
The input parameters of @chauffeur_afni for -func_resam expect one of NN, Li, Cu or Bk. The logic in the script reports an error because it is ORing those tests. This means you cannot use this functionality at all because it is impossible for the value to be all of those at once.

A simple inversion of the logical OR to AND and all is well.

We have tested this in our project, where we found the problem in the first place, and it resolves nicely.