### PR TITLE
atlas left-right label handling

### DIFF
--- a/src/thd_ttatlas_query.c
+++ b/src/thd_ttatlas_query.c
@@ -3501,9 +3501,11 @@ not sure why it was there in the first place!
          if (LocalHead) fprintf(stderr,"Have chunk %s, will eat...\n", lachunk);
          sd = '\0';
          if (aar->N_chnks == 0) { /* check on side */
-          /* side checking doesn't work generically across atlases -
-              needs specific left-right masks or x=0 separation, neither mandatory */
-            sd = 'u';    // removing side checking drg 2024 Is_Side_Label(lachunk, NULL);
+            /* side checking doesn't work generically across atlases -
+               needs specific left-right masks or x=0 separation, 
+               neither mandatory */
+            // removing side checking drg 2024 Is_Side_Label(lachunk, NULL);
+            sd = 'u'; 
             if (LocalHead)
                fprintf(stderr,"Side check on %s returned %c\n", lachunk, sd);
             if (sd == 'l' || sd == 'r' || sd == 'b') {

--- a/src/thd_ttatlas_query.c
+++ b/src/thd_ttatlas_query.c
@@ -2838,6 +2838,7 @@ char Is_Side_Label(char *str, char *opt)
    char *strd=NULL;
    ENTRY("atlas_label_side");
 
+RETURN('u');
    if (!str) RETURN('u');
 
    strd = strdup(str);
@@ -3496,7 +3497,9 @@ not sure why it was there in the first place!
          if (LocalHead) fprintf(stderr,"Have chunk %s, will eat...\n", lachunk);
          sd = '\0';
          if (aar->N_chnks == 0) { /* check on side */
-            sd = Is_Side_Label(lachunk, NULL);
+          /* side checking doesn't work generically across atlases -
+              needs specific left-right masks or x=0 separation, neither mandatory */
+            sd = 'u';    // removing side checking drg 2024 Is_Side_Label(lachunk, NULL);
             if (LocalHead)
                fprintf(stderr,"Side check on %s returned %c\n", lachunk, sd);
             if (sd == 'l' || sd == 'r' || sd == 'b') {
@@ -3527,7 +3530,7 @@ not sure why it was there in the first place!
       /* first check on side */
       sd = '\0';
       if (aar->N_chnks == 0) { /* check on side */
-         sd = Is_Side_Label(lachunk, NULL);
+         sd = 'u';    // removing side checking drg 2024 Is_Side_Label(lachunk, NULL);
          if (LocalHead)
             fprintf(stderr,"Side check on %s returned %c\n", lachunk, sd);
          if (sd == 'l' || sd == 'r' || sd == 'b') {

--- a/src/thd_ttatlas_query.c
+++ b/src/thd_ttatlas_query.c
@@ -2836,9 +2836,13 @@ char Is_Side_Label(char *str, char *opt)
 {
    int k, nc;
    char *strd=NULL;
-   ENTRY("atlas_label_side");
+   ENTRY("Is_Side_Label");
 
-RETURN('u');
+   /* return without doing anything because left and right
+       can be determined just from region labels without
+       this fanciness / shenanigans */
+   RETURN('u');
+
    if (!str) RETURN('u');
 
    strd = strdup(str);


### PR DESCRIPTION
Left-right labels in an atlas name use could cut off regions that crossed 0,0,0 lines. This could happen even if the "left", "right", "both" were specified. Since abandoning the lr masks from the MNI_N27 and TT_N27 datasets, these were no longer used for left, right determination and weren't valid for other atlases in any case.

```
3dBrickStat -count -non-zero 'CA_ML_18_MNI::Left_SMA'
3dcalc -a CA_ML_18_MNI::Left_SMA -expr a ...
```
This solution removes the left or right label determination that is then used to mask the dataset based on 
coordinates.

