### PR TITLE
in any script calling whereami, envoke with tcsh -f at top

### DIFF
--- a/src/afni_history_rickr.c
+++ b/src/afni_history_rickr.c
@@ -54,7 +54,7 @@
 afni_history_struct rickr_history[] = {
 
  { 26, Apr, 2024, RCR, "afni-general", MINOR, TYPE_MODIFY,
-   "in any script calling whereami, envoke with 'tcsh -f' at top",
+   "in any script calling whereami, invoke with 'tcsh -f' at top",
    "This is a quick fix for biowulf usage, since there is a new whereami\n"
    "in town (/usr/local/bin/wheremai), and because they reset the PATH.\n"
    "Modify: @Atlasize @MakeLabelTable @chauffeur_afni\n"

--- a/src/afni_history_rickr.c
+++ b/src/afni_history_rickr.c
@@ -53,6 +53,14 @@
 
 afni_history_struct rickr_history[] = {
 
+ { 26, Apr, 2024, RCR, "afni-general", MINOR, TYPE_MODIFY,
+   "in any script calling whereami, envoke with 'tcsh -f' at top",
+   "This is a quick fix for biowulf usage, since there is a new whereami\n"
+   "in town (/usr/local/bin/wheremai), and because they reset the PATH.\n"
+   "Modify: @Atlasize @MakeLabelTable @chauffeur_afni\n"
+   "        compute_ROI_stats.tcsh gen_cluster_table"
+ } ,
+
  { 26, Apr, 2024, RCR, "gen_ss_review_scripts.py", MINOR, TYPE_ENHANCE,
    "-init_uvars_json will now pass through unknown uvars",
    "This enables users to pass uvars through afni_proc.py to the APQC."

--- a/src/scripts_install/@Atlasize
+++ b/src/scripts_install/@Atlasize
@@ -1,4 +1,4 @@
-#!/bin/tcsh
+#!/bin/tcsh -f
 
 @global_parse `basename $0` "$*" ; if ($status) exit 0
 

--- a/src/scripts_install/@MakeLabelTable
+++ b/src/scripts_install/@MakeLabelTable
@@ -1,4 +1,4 @@
-#!/bin/tcsh
+#!/bin/tcsh -f
 onintr END
 
 @global_parse `basename $0` "$*" ; if ($status) exit 0

--- a/src/scripts_install/@chauffeur_afni
+++ b/src/scripts_install/@chauffeur_afni
@@ -1,4 +1,4 @@
-#!/bin/tcsh
+#!/bin/tcsh -f
 
 # for olay, default will be "show all"-- update fatcats to call for
 # 98%iles of non-zeros

--- a/src/scripts_install/compute_ROI_stats.tcsh
+++ b/src/scripts_install/compute_ROI_stats.tcsh
@@ -1,4 +1,4 @@
-#!/usr/bin/env tcsh
+#!/bin/tcsh -f
 
 # ===========================================================================
 # compute ROI statistics (intended for TSNR dset)

--- a/src/scripts_install/gen_cluster_table
+++ b/src/scripts_install/gen_cluster_table
@@ -1,4 +1,4 @@
-#!/bin/tcsh
+#!/bin/tcsh -f
 
 @global_parse `basename $0` "$*" ; if ($status) exit 0
 


### PR DESCRIPTION
This is a quick fix for biowulf usage, since there is a new whereami in town (/usr/local/bin/wheremai), and because they reset the PATH. Modify: @Atlasize @MakeLabelTable @chauffeur_afni compute_ROI_stats.tcsh gen_cluster_table