### PR TITLE
3dRetinoPhase delay based estimation seg fault fix

### DIFF
--- a/src/plug_delay_V2.h
+++ b/src/plug_delay_V2.h
@@ -1291,7 +1291,24 @@ static int hilbertdelay_V2 (float *x,
    
    *del = NoWayDelay;              /* initialize to an unlikely value ...*/
    *xcorCoef = NoWayxcorCoef;          
-
+   /* [BP: Jan 2, 2024] if x or y are NULL there's nothing more to do. This 
+      scenario occurs when when this function is called by 
+      hilbertdelay_V2reset. In this case del and xcorCoef pointers are also
+      NULL, which will cause a segfault when attempting to
+      dereference them in the next few lines of code, but because there's
+      nothing to evaluate, PT's logic re: 3dDelay above shouldn't apply.
+   */
+   if (x == NULL || y == NULL) {
+     return (0);
+   } 
+   else if (del == NULL || xcorCoef == NULL ) {
+     sprintf (buf,"Cannot evaluate with NULL delay or xcorr coef.\n");
+     error_message("hilbertdelay_V2",buf,0);
+     return (ERROR_OPTIONS);
+   } else {
+     *del = NoWayDelay;              /* initialize to an unlikely value ...*/
+     *xcorCoef = NoWayxcorCoef;          
+   }
 
    /*--------------------------------------------------------------------------*/
    /* First call, init. and do computations for reference time series          */


### PR DESCRIPTION
3dRetinoPhase initializes the Delay based method of estimation by invoking hilbertdelay_V2reset(); This is just a simple wrapper for hilbertdelay_V2() which it calls with opt=0, *del=NULL and *xcorCoef=Null arguments, among others. This combination of parameters results in the dereferencing of the del and xcorCoeff pointers on lines 1292 and 1293 of plug_delay_V2.h when an attempt is made to assign them values, but for null pointers this operation causes a segmentation fault.

Instead we can determine if there's anything to compute after cleaning up all the other variables in the opt=0 block from lines 1245 - 1289, and if the x and y variables are NULL then we return at that point. This implicitly avoids dereferencing the NULL del and xcorCoef pointers since x and y should be NULL anytime del and xcorCoef are NULL.

This issue is discussed more fully in Issue #556