### PR TITLE
Homebrew gcc-14 new requirements on C code

### DIFF
--- a/src/3dExchange.c
+++ b/src/3dExchange.c
@@ -157,9 +157,9 @@ int main( int argc , char * argv[] )
       fac = DSET_BRICK_FACTOR(dset, i); /* get scale factor for each sub-brik*/
       if(fac==0.0) fac=1.0;
       nvox = data_im->nvox;             /* number of voxels in the sub-brik */
-
-      outfar = outsar = outbar = mri_data_pointer(out_data_im);
-
+      outbar = (byte *) mri_data_pointer(out_data_im);
+      outfar = mri_data_pointer(out_data_im);
+      outsar = mri_data_pointer(out_data_im);
       badsb_type = 0;
       switch(data_im->kind){
            case MRI_short:{

--- a/src/3dExchange.c
+++ b/src/3dExchange.c
@@ -158,8 +158,8 @@ int main( int argc , char * argv[] )
       if(fac==0.0) fac=1.0;
       nvox = data_im->nvox;             /* number of voxels in the sub-brik */
       outbar = (byte *) mri_data_pointer(out_data_im);
-      outfar = mri_data_pointer(out_data_im);
-      outsar = mri_data_pointer(out_data_im);
+      outfar = (float *) mri_data_pointer(out_data_im);
+      outsar = (short *) mri_data_pointer(out_data_im);
       badsb_type = 0;
       switch(data_im->kind){
            case MRI_short:{

--- a/src/Makefile.macos_11_ARM_clang
+++ b/src/Makefile.macos_11_ARM_clang
@@ -85,7 +85,7 @@ XLIBS = -lXm -ljpeg -lXt
 
 CCDEBS = -DAFNI_DEBUG -DIMSEQ_DEBUG -DDISPLAY_DEBUG -DTHD_DEBUG
 CEXTRA = -m64 -Wall -Wno-deprecated-declarations -Wcomment -Wformat -DUSE_TRACING -DHAVE_XDBE \
-	 -DDONT_USE_MCW_MALLOC $(LESSTIF_DEFS)
+	 -Wno-implicit-int -DDONT_USE_MCW_MALLOC $(LESSTIF_DEFS)
 # choose gcc version below from homebrew directory in 
 # either /opt/homebrew/bin
 # or Apple clang from /usr/bin with 

--- a/src/SUMA/SUMA_clippingPlanes.c
+++ b/src/SUMA/SUMA_clippingPlanes.c
@@ -1535,7 +1535,7 @@ void lightenActiveClipPlaneSquare(int planeIndex){
 
        // switch to the recently loaded  cmap
         SUMA_COLOR_MAP *Cmp = SUMA_FindNamedColMap ("ngray20");
-        Cmp->idvec = SO->idcode_str;
+//        Cmp->idvec = SO->idcode_str;
         if (!SUMA_SwitchColPlaneCmap(ado, Cmp)) {
             fprintf(stderr, "Failed in SUMA_SwitchColPlaneCmap");
             return;
@@ -1593,7 +1593,7 @@ void lightenActiveClipPlaneSquare(int planeIndex){
 
        // switch to the recently loaded  cmap
         SUMA_COLOR_MAP *Cmp = SUMA_FindNamedColMap ("ngray20");
-        Cmp->idvec = SO->idcode_str;
+//        Cmp->idvec = SO->idcode_str;
         if (SUMAg_CF->clippingPlaneVerbose && SUMAg_CF->clippingPlaneVerbosityLevel>1)
         {
             fprintf(stderr, "### Darken clipping plane square: switch to the recently loaded  cmap\n");

--- a/src/SUMA/SUMA_clippingPlanes.c
+++ b/src/SUMA/SUMA_clippingPlanes.c
@@ -1535,7 +1535,7 @@ void lightenActiveClipPlaneSquare(int planeIndex){
 
        // switch to the recently loaded  cmap
         SUMA_COLOR_MAP *Cmp = SUMA_FindNamedColMap ("ngray20");
-//        Cmp->idvec = SO->idcode_str;
+        /* Cmp->idvec = SO->idcode_str; */
         if (!SUMA_SwitchColPlaneCmap(ado, Cmp)) {
             fprintf(stderr, "Failed in SUMA_SwitchColPlaneCmap");
             return;
@@ -1593,7 +1593,7 @@ void lightenActiveClipPlaneSquare(int planeIndex){
 
        // switch to the recently loaded  cmap
         SUMA_COLOR_MAP *Cmp = SUMA_FindNamedColMap ("ngray20");
-//        Cmp->idvec = SO->idcode_str;
+        /* Cmp->idvec = SO->idcode_str; */
         if (SUMAg_CF->clippingPlaneVerbose && SUMAg_CF->clippingPlaneVerbosityLevel>1)
         {
             fprintf(stderr, "### Darken clipping plane square: switch to the recently loaded  cmap\n");

--- a/src/SUMA/SUMA_glxdino.c
+++ b/src/SUMA/SUMA_glxdino.c
@@ -151,8 +151,10 @@ extrudeSolidFromPolygon(GLfloat data[][2], unsigned int dataSize,
     tobj = gluNewTess();  /* create and initialize a GLU
                              polygon tessellation object */
     /* cast 3rd args as _GLUfuncptr for some machines   02 Aug 2004 [rickr] */
-    gluTessCallback(tobj, GLU_BEGIN, CAST_GLU_FUNCPTR glBegin);
-    gluTessCallback(tobj, GLU_VERTEX, CAST_GLU_FUNCPTR glVertex2fv);/* tricky */
+    gluTessCallback(tobj, GLU_BEGIN,  (void *) glBegin);
+//    gluTessCallback(tobj, GLU_BEGIN, CAST_GLU_FUNCPTR glBegin);
+    gluTessCallback(tobj, GLU_VERTEX, (void *) glVertex2fv);/* tricky */
+//    gluTessCallback(tobj, GLU_VERTEX, CAST_GLU_FUNCPTR glVertex2fv);/* tricky */
     gluTessCallback(tobj, GLU_END, CAST_GLU_FUNCPTR glEnd);
   }
   glNewList(side, GL_COMPILE);

--- a/src/XmHTML/lib/Motif/motif.c
+++ b/src/XmHTML/lib/Motif/motif.c
@@ -281,7 +281,7 @@ DestroyImage(XImage *image)
 }
 
 static unsigned long
-GetPixelWrapper(XImage *ximage, Dimension x, Dimension y)
+GetPixelWrapper(XImage *ximage, _XtDimension  x, _XtDimension  y)
 {
 	return(XGetPixel(ximage, x, y));
 }

--- a/src/XmHTML/lib/common/psoutput.c
+++ b/src/XmHTML/lib/common/psoutput.c
@@ -220,7 +220,7 @@ static ToolkitAbstraction *_CreatePostscriptTka(XmHTMLWidget html);
 static int pstkSetForeground(Display *disp, XGC gc, unsigned long foreground);
 static int pstkSetFont(Display *disp, XGC gc, XmHTMLfont *font);
 static int pstkDrawString(Display *disp, DRAWABLE win,
-	struct _XmHTMLFont *font, XGC gc, int x, int y, char *string, int length);
+	struct _XmHTMLFont *font, XGC gc, int x, int y, const char *string, int length);
 static void pstkDrawAnchorData(Display *disp, WINDOW win, XGC gc, int x,
 	int y, XmHTMLObjectTableElement data);
 static int pstkDrawLine(Display *disp, WINDOW win, XGC gc, int x1, int y1,
@@ -1888,7 +1888,7 @@ pstkCopyArea(Display *disp, DRAWABLE src, DRAWABLE dest, XGC gc, int src_x,
 *****/
 static int
 pstkDrawString(Display *disp, DRAWABLE win, struct _XmHTMLFont *font,
-	XGC gc, int x, int y, char *string, int length)
+	XGC gc, int x, int y, const char *string, int length)
 {
 	PSDisplay *dpy = (PSDisplay*)disp;
 	static char *last_ep=NULL;

--- a/src/jpeg-6b/configure
+++ b/src/jpeg-6b/configure
@@ -623,7 +623,7 @@ cross_compiling=$ac_cv_prog_cc_cross
 cat > conftest.$ac_ext <<EOF
 #line 625 "configure"
 #include "confdefs.h"
-main(){return(0);}
+int main(){return(0);}
 EOF
 if { (eval echo configure:629: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest; then
   ac_cv_prog_cc_works=yes


### PR DESCRIPTION
gcc-14 is the latest default version for homebrew with `brew install gcc`. That latest version of gcc imposes some C code updates like requiring int declarations for functions that return integers. Updates to ignore some warnings with -Wno-implicit-int (f2c code built from Fortran would need to be updated with each conversion) and a couple small other declaration fixes solves the complaints of this version of the gcc compiler.

The libjpeg.a update only occurs in the configure command script it uses to determine compiler properties and not in the AFNI source code.

The libXmHTML code required two small changes for consistent type declarations.