### PR TITLE
Enhance docker recipes: install atlases, make AFNI_PATH point to the /opt/afni not /src under it

### DIFF
--- a/.docker/afni_dev_base.dockerfile
+++ b/.docker/afni_dev_base.dockerfile
@@ -27,9 +27,9 @@ ENV SHELL=/bin/bash \
     TINI_SUBREAPER="" \
     LANG="en_US.UTF-8" \
     LC_ALL="en_US.UTF-8" \
-    AFNI_ROOT=/opt/afni/src
+    AFNI_ROOT=/opt/afni
 
-ENV DESTDIR="$AFNI_ROOT/../install" \
+ENV DESTDIR="$AFNI_ROOT/install" \
     PATH="$PYTHONUSERBASE/bin:$PATH" \
     HOME=/home/$CONTAINER_USER
 
@@ -140,8 +140,7 @@ RUN fix-permissions /opt
 USER $CONTAINER_UID
 
 ###### Switch to non privileged user ######
-
-RUN bash -c 'mkdir -p $AFNI_ROOT/../{build,src,install} && fix-permissions $AFNI_ROOT/../..'
+RUN bash -c 'mkdir -p $AFNI_ROOT/{build,src,install} && fix-permissions $AFNI_ROOT/..'
 
 # [PT: 2025-xx-xx] Bump CMake from 3.14.7 -> 3.31.7 (CMakeLists.txt requires >= 3.16).
 # Note: starting with CMake 3.20, the prebuilt tarball uses lowercase "linux"

--- a/.docker/afni_dev_base.dockerfile
+++ b/.docker/afni_dev_base.dockerfile
@@ -29,7 +29,8 @@ ENV SHELL=/bin/bash \
     LC_ALL="en_US.UTF-8" \
     AFNI_ROOT=/opt/afni
 
-ENV DESTDIR="$AFNI_ROOT/install" \
+ENV AFNI_ATLAS_PATH="$AFNI_ROOT/atlases" \
+    DESTDIR="$AFNI_ROOT/install" \
     PATH="$PYTHONUSERBASE/bin:$PATH" \
     HOME=/home/$CONTAINER_USER
 
@@ -37,8 +38,7 @@ ENV DESTDIR="$AFNI_ROOT/install" \
 # should be set in /etc/environment (variables set by ENV do not cleanly
 # propagate to all users). Should do this for PATH again later in the dockerfile (or
 # child files)
-ENV PRESERVED_VARS "PYTHONUSERBASE AFNI_ROOT DESTDIR PATH TINI_SUBREAPER LC_ALL"
-
+ENV PRESERVED_VARS "PYTHONUSERBASE AFNI_ATLAS_PATH AFNI_ROOT DESTDIR PATH TINI_SUBREAPER LC_ALL"
 RUN bash -c 'for val in $PRESERVED_VARS;do \
     echo $val=${!val} >> /etc/environment ; \
 done'
@@ -191,6 +191,12 @@ RUN python3 -m pip install \
     && git config --global user.name "Docker Almighty" \
     && git config --global user.email "nobody@example.com" \
     && datalad wtf
+
+# Install atlases
+RUN wget -nv -O /tmp/afni_atlases.tgz https://afni.nimh.nih.gov/pub/dist/atlases/afni_atlases_dist.tgz \
+    && mkdir "$AFNI_ROOT/atlases" \
+    && tar -xzf /tmp/afni_atlases.tgz -C "$AFNI_ROOT/atlases" --strip-components=1 \
+    && rm /tmp/afni_atlases.tgz
 
 # add pdb alias ipy for easier pdb debugging
 RUN echo 'alias ipy from IPython import embed;embed()' >> ~/.pdbrc

--- a/.docker/afni_dev_base.dockerfile
+++ b/.docker/afni_dev_base.dockerfile
@@ -194,8 +194,8 @@ RUN python3 -m pip install \
 
 # Install atlases
 RUN wget -nv -O /tmp/afni_atlases.tgz https://afni.nimh.nih.gov/pub/dist/atlases/afni_atlases_dist.tgz \
-    && mkdir "$AFNI_ROOT/atlases" \
-    && tar -xzf /tmp/afni_atlases.tgz -C "$AFNI_ROOT/atlases" --strip-components=1 \
+    && mkdir "$AFNI_ATLAS_PATH" \
+    && tar -xzf /tmp/afni_atlases.tgz -C "$AFNI_ATLAS_PATH" --strip-components=1 \
     && rm /tmp/afni_atlases.tgz
 
 # add pdb alias ipy for easier pdb debugging

--- a/.docker/cmake_build.dockerfile
+++ b/.docker/cmake_build.dockerfile
@@ -7,9 +7,9 @@ ENV PATH=$DESTDIR/usr/local/bin:$PATH
 ARG AFNI_WITH_COVERAGE="0"
 
 # Copy AFNI source code. This will likely invalidate the build cache.
-COPY --chown=$CONTAINER_UID:$CONTAINER_GID . $AFNI_ROOT/
+COPY --chown=$CONTAINER_UID:$CONTAINER_GID . $AFNI_ROOT/src/
 
-WORKDIR $AFNI_ROOT/../build
+WORKDIR $AFNI_ROOT/build
 
 RUN \
     export CC=`which gcc`;\
@@ -26,7 +26,7 @@ RUN \
         -DCOMP_GUI=ON \
         -DCOMP_PLUGINS=ON \
         -DUSE_OMP=ON \
-        $AFNI_ROOT
+        $AFNI_ROOT/src
 
 RUN /bin/bash -oc pipefail \
 'ninja -v 2>&1 | tee verbose_build.log && test ${PIPESTATUS[0]} -eq 0'

--- a/.docker/make_build.dockerfile
+++ b/.docker/make_build.dockerfile
@@ -4,33 +4,33 @@ FROM afni/afni_dev_base
 USER root
 RUN apt-get remove -y libf2c2-dev
 
-ENV DESTDIR=$AFNI_ROOT/../install
+ENV DESTDIR=$AFNI_ROOT/install
 ENV PATH=$DESTDIR:$PATH
 
 # Copy AFNI source code. This will likely invalidate the build cache.
-COPY --chown=$CONTAINER_UID:$CONTAINER_GID . $AFNI_ROOT/
+COPY --chown=$CONTAINER_UID:$CONTAINER_GID . $AFNI_ROOT/src/
 
 # Not supported, try the cmake build for coverage testing
 ENV AFNI_WITH_COVERAGE=false
 
 ARG AFNI_MAKEFILE_SUFFIX=linux_ubuntu_16_64_glw_local_shared
 ARG KEEP_BUILD_DIR="0"
-RUN cd $AFNI_ROOT/src \
+RUN cd $AFNI_ROOT/src/src \
     && make -f  other_builds/Makefile.$AFNI_MAKEFILE_SUFFIX afni_src.tgz \
-    && tar -xzf afni_src.tgz -C $AFNI_ROOT/../build --strip-components=1 \
+    && tar -xzf afni_src.tgz -C $AFNI_ROOT/build --strip-components=1 \
     && rm afni_src.tgz \
     # copy and possibly modify makefile
-    && cd $AFNI_ROOT/../build \
+    && cd $AFNI_ROOT/build \
     && cp other_builds/Makefile.$AFNI_MAKEFILE_SUFFIX Makefile \
     # clean and move source code to build directory
     && make cleanest \
     # Build AFNI.
     && /bin/bash -c \
     'make itall 2>&1 | tee build_log.txt && test ${PIPESTATUS[0]} -eq 0' \
-    && mv $AFNI_MAKEFILE_SUFFIX/* $AFNI_ROOT/../install \
+    && mv $AFNI_MAKEFILE_SUFFIX/* $AFNI_ROOT/install \
     # Remove build tree to drop image size
     && if [ "$KEEP_BUILD_DIR" = "0" ]; then \
-      rm -rf $AFNI_ROOT/../build; \
+      rm -rf $AFNI_ROOT/build; \
       fi
 
 USER root


### PR DESCRIPTION
- set AFNI_PATH to /opt/afni not /opt/afni/src which simplifies use of that variable (there is more of $AFNI_PATH/.. than of just $AFNI_PATH) and avoids odd `/opt/afni/src/../install` in the PATH variable).  This variable seems to not be used in the afni source code base so I assume that such change is ok, but @leej3 might shine more light on that.
- install atlases under /opt/afni/atlases and set `AFNI_ATLAS_PATH` . Done this way so it should work for both `make` and `cmake` flavors. Closes #646  . Analogous solution tested in https://github.com/afni/afni_proc_simple_bids_app/pull/3