### PR TITLE
escape the escapes

### DIFF
--- a/src/python_scripts/afnipy/db_mod.py
+++ b/src/python_scripts/afnipy/db_mod.py
@@ -6826,7 +6826,7 @@ def db_cmd_regress(proc, block):
             if stop_opt: fstr += '\n'
             fstr += "%s# create fitts from REML errts\n" % istr
             fstr += "%s3dcalc -a %s%s -b %s%s -expr a-b \\\n" \
-                    "%s       -prefix %s\_REML%s\n"                 \
+                    "%s       -prefix %s\\_REML%s\n"          \
                     % (istr, proc.all_runs, vstr, proc.errts_reml, vstr,
                        istr, fitts_pre, suff)
         cmd = cmd + fstr + feh_end + '\n'

--- a/src/python_scripts/scripts/align_epi_anat.py
+++ b/src/python_scripts/scripts/align_epi_anat.py
@@ -1968,7 +1968,7 @@ class RegWrap:
        else: status = 0
        return (status)
      
-   # determine if dataset is oblique
+   # determine if dataset is oblique:
    def oblique_dset( self, dset=None) :
       com = shell_com(  \
         "3dinfo %s | \\grep 'Data Axes Tilt:'| \\grep 'Oblique'" %dset.input(),\

--- a/src/python_scripts/scripts/align_epi_anat.py
+++ b/src/python_scripts/scripts/align_epi_anat.py
@@ -1971,7 +1971,7 @@ class RegWrap:
    # determine if dataset is oblique
    def oblique_dset( self, dset=None) :
       com = shell_com(  \
-        "3dinfo %s | \grep 'Data Axes Tilt:'|\grep 'Oblique'" % dset.input(),\
+        "3dinfo %s | \\grep 'Data Axes Tilt:'| \\grep 'Oblique'" %dset.input(),\
           ps.oexec,capture=1)
       com.run()
       if  ps.dry_run():
@@ -2776,7 +2776,7 @@ class RegWrap:
                        (ps.dset1_generic_name, ps.dset2_generic_name ))
 
             warp_str = "3dWarp -verb -card2oblique %s -prefix %s%s %s %s %s " \
-                     "  | \grep  -A 4 '# mat44 Obliquity Transformation ::'"  \
+                     "  | \\grep  -A 4 '# mat44 Obliquity Transformation ::'" \
                      "  > %s"                                                 \
                     % (e.input(), o.p(), o.out_prefix(),                      \
                      self.master_anat_option, oblique_opt,                    \


### PR DESCRIPTION
python is viewing the \ chars as escapes, so they should be passed through to the shell