### PR TITLE
allow smaller spheres in Draw Dataset

### DIFF
--- a/src/plug_drawdset.c
+++ b/src/plug_drawdset.c
@@ -833,11 +833,11 @@ void DRAW_make_widgets(void)
      rad_av = new_MCW_arrowval( rc             ,    /* parent */
                                 "R"            ,    /* label */
                                 MCW_AV_downup  ,    /* arrow directions */
-                                1              ,    /* min value (0.1 mm from decim) */
-                                999            ,    /* max value (99.9 mm) */
-                                40             ,    /* init value */
+                                1              ,    /* min value (0.01 mm from decim) */
+                                9999            ,   /* max value (99.99 mm) */
+                                400             ,   /* init value */
                                 MCW_AV_editext ,    /* input/output text display */
-                                1              ,    /* decimal shift */
+                                2              ,    /* decimal shift */
                                 NULL           ,    /* routine to call when button */
                                 NULL           ,    /* is pressed, and its data */
                                 NULL,NULL           /* no special display */


### PR DESCRIPTION
The Draw Dataset plugin does not allow a radius smaller than 0.1mm for spherical and circular ROIs. This becomes an issue for volumes with very fine resolution, as sometimes seen with mouse, rat and marmoset imaging. This modification shifts the decimal point and allows changes down to 0.01mm.
