### PR TITLE
fix plotting issue when mean opt used

### DIFF
--- a/src/R_scripts/RBA.R
+++ b/src/R_scripts/RBA.R
@@ -1289,8 +1289,9 @@ if(any(!is.na(lop$qContr) == TRUE)) for(ii in 1:(length(lop$qContrL)/2)) {
 
 # for factor
 if(any(!is.na(lop$EOIc) == TRUE)) for(ii in 1:length(lop$EOIc)) {
-   lvl <- levels(lop$dataTable[[lop$EOIc[ii]]])  # levels
-   nl <- nlevels(lop$dataTable[[lop$EOIc[ii]]])  # number of levels: last level is the reference in deviation coding
+   lvl <- levels(as.factor(lop$dataTable[[lop$EOIc[ii]]]))  # levels
+   nl <- nlevels(as.factor(lop$dataTable[[lop$EOIc[ii]]]))  # number of levels: last level is the reference in deviation coding
+   nR <- nlevels(as.factor(lop$dataTable[[lop$ROI]])) # number of ROIs
    ps <- array(0, dim=c(nl, ns, nR)) # posterior samples
    for(jj in 1:(nl-1)) ps[jj,,] <- psROI(aa, bb, paste0(lop$EOIc[ii],jj))
    ps[nl,,] <- psROI(aa, bb, 'Intercept') # Intercept: average effect 


### PR DESCRIPTION
The CLI call `RBA -mean 'Y~1+Fac+(1+Fac|Subj)+(1+Fac|ROI) -EOI 'Fac' ...` results in the plotting error `Error: object 'nR' not found` due to line 1297 attempting to use the variable `nR` which was not set (line 789) as the `-mean` option and not `-model` was used in the call.

Adding line 1294 resolves this issue but reveals the error 
```
Error in `[<-`(`*tmp*`, jj, , , value = psROI(aa, bb, paste0(lop$EOIc[ii],  : 
  subscript out of bounds
```
which stems from lines 1292, 1293 attempting to count factors which were never set (line 789) for the same reason as above. Updating these lines resolves this error.