### PR TITLE
AP suggestion: handle/fail differently for polort<0 in 3dToutcount

### DIFF
--- a/src/python_scripts/afnipy/db_mod.py
+++ b/src/python_scripts/afnipy/db_mod.py
@@ -906,8 +906,17 @@ def make_outlier_commands(proc, block):
     # set polort level
     val, err = proc.user_opts.get_type_opt(int, '-outlier_polort')
     if err: return
-    elif val != None and val >= 0: polort = val
-    else: polort = proc.regress_polort
+    elif val != None :
+        if val >= 0: 
+            polort = val
+        else: 
+            print("** ERROR: -outlier_polort must be >=0")
+            return -1, ''
+    else: 
+        polort = proc.regress_polort
+        if polort < 0 :
+            print("** ERROR: Using -regress_polort for 3dToutcount, but is <0")
+            return -1, ''
 
     # use Legendre polynomials?
     opt = proc.user_opts.find_opt('-outlier_legendre')

--- a/src/python_scripts/afnipy/db_mod.py
+++ b/src/python_scripts/afnipy/db_mod.py
@@ -916,6 +916,7 @@ def make_outlier_commands(proc, block):
         polort = proc.regress_polort
         if polort < 0 :
             print("** ERROR: Using -regress_polort for 3dToutcount, but is <0")
+            print("   Perhaps consider using the '-outlier_polort' option?")
             return -1, ''
 
     # use Legendre polynomials?


### PR DESCRIPTION
@afni-rickr : 

What do you think about this change in handling polort values for 3dToutcount?  This was prompted by a case in which a user had `-regress_polort -1`, which created a failure later on down the road in the proc script execution.

Separately, 3dToutcount fails with polort <0, but with the wrong error message, so I am going to edit that in the master branch.

Basically, 3dToutcount cannot have a polort <0.  This puts a check for that earlier on, and fails if a user advertently or inadvertently creates a situation for that.  But there may be better ways to implement this in the code.  I have greatly expanded the number of lines in this function...

