### PR TITLE
Sort datasets in dataset choosers 

### DIFF
--- a/doc/README/README.environment
+++ b/doc/README/README.environment
@@ -368,6 +368,16 @@ the directory name are used for the display. If AFNI_SESSTRAIL
 is not set, then it is equivalent to setting it to 0 (which
 was the old method).
 
+---------------------------
+Variable: AFNI_SESSION_SORT
+---------------------------
+This is a string to set the sort order within the dataset choosers
+in the afni GUI. The allowed values are
+ALPHA    = alphabetical, case insensitive (A=a)
+REVALPHA = reverse alphabetical
+MRITYPE  = dataset type - anatomical, functional
+NONE     = previous default sorting of MRI type, then NIFTI, other types
+
 --------------------
 Variable: AFNI_HINTS
 --------------------

--- a/doc/README/README.environment
+++ b/doc/README/README.environment
@@ -373,10 +373,10 @@ Variable: AFNI_SESSION_SORT
 ---------------------------
 This is a string to set the sort order within the dataset choosers
 in the afni GUI. The allowed values are
-ALPHA    = alphabetical, case insensitive (A=a) (order=numeric,alpha,underscore)
-REVALPHA = reverse alphabetical
+ALPHA    = alphabetical, case insensitive (A=a) (numeric,alpha Aa-Zz,underscore)
+REVALPHA = reverse alphabetical (reverse of ALPHA:underscore,zZ-aA,numeric)
 MRITYPE  = dataset type - anatomical, functional
-NONE     = previous default sorting of MRI type, then NIFTI, other types
+NONE     = no sorting at all, but order of filling is AFNI then NIFTI
 
 --------------------
 Variable: AFNI_HINTS

--- a/doc/README/README.environment
+++ b/doc/README/README.environment
@@ -373,7 +373,7 @@ Variable: AFNI_SESSION_SORT
 ---------------------------
 This is a string to set the sort order within the dataset choosers
 in the afni GUI. The allowed values are
-ALPHA    = alphabetical, case insensitive (A=a)
+ALPHA    = alphabetical, case insensitive (A=a) (order=numeric,alpha,underscore)
 REVALPHA = reverse alphabetical
 MRITYPE  = dataset type - anatomical, functional
 NONE     = previous default sorting of MRI type, then NIFTI, other types

--- a/src/afni_history_dglen.c
+++ b/src/afni_history_dglen.c
@@ -53,6 +53,14 @@
 
 
 afni_history_struct dglen_history[] = {
+{ 12, SEP, 2025, DRG, "afni",
+     MINOR, TYPE_ENHANCE,
+    "afni GUI can now sort datasets in chooser alphabetically",
+    "Previously, sessions were sorted by anatomical, func, then NIFTI.\n"
+    "Now the user has options to set alphabetic, reverse alphabetic,\n"
+    "mri type (data type including NIFTI) or no re-sorting (original \n"
+    "mri type then NIFTI) using AFNI environment variables."
+},
 { 19, AUG, 2025, DRG, "3dXYZcat",
      MICRO, TYPE_BUG_FIX,
     "3dXYZcat generated extra empty volume in X direction"

--- a/src/thd_initsess.c
+++ b/src/thd_initsess.c
@@ -15,6 +15,7 @@ static int compare_qsort_dsrows(const void *dsr1, const void *dsr2);
 static int compare_real_strings (char *a, char *b );
 static SORT_order get_dsrow_sortorder(void);
 static void set_dsrow_sortorder(SORT_order sortorder);
+static int strucasecmp(const char *s1, const char *s2);
 
 /*---------------------------------------------------------------------
    Given a directory name, read in all the datasets and make
@@ -1029,7 +1030,7 @@ static int compare_real_strings (char *a, char *b )
    if (!a && !b) return(0);
    if (!a) return(-1);
    if (!b) return(1);
-   return (strcasecmp(a, b));
+   return (strucasecmp(a, b));
 }
 
 /* set the sortorder of rows of datasets in sessions (for dataset choosers) */
@@ -1068,4 +1069,17 @@ static SORT_order get_dsrow_sortorder()
    }
 
    return(dsrow_sortorder);
+}
+
+/* use uppercase version of strcasecmp for comparison (vs lower case)
+ * mostly to avoid __tt... datasets appearing before alphabetic */
+static int strucasecmp(const char *s1, const char *s2)
+{
+    int c1, c2;
+
+    do {
+        c1 = toupper(*s1++);
+        c2 = toupper(*s2++);
+    } while (c1 == c2 && c1 != 0);
+    return c1 - c2;
 }


### PR DESCRIPTION
This update sorts datasets in the AFNI GUI dataset choosers like Underlay and Overlay choosers. Previously, datasets were ordered in an apocryphal order related to their dataset type and their data format with anatomical datasets first, followed by all other types. AFNI format was  included first and then NIFTI and other types of datasets.

The new orders allow for simple alphabetic, reverse alphabetic, dataset type (anatomical, echo planar, functional bucket - a little like the original, but includes NIFTI), or the default order the datasets are read in (close to the original method). I haven't preserved the real original sort, but that could be added in if someone wants that.

Tested with datasets with mixed spaces and formats. Read in new sessions, added new datasets after reading session, used AFNI_GLOBAL_SESSION.

We could make this an environment variable that can be changed within the GUI easily or a sort control within the chooser.
