### PR TITLE
Crosshair gap size

### DIFF
--- a/doc/README/README.environment
+++ b/doc/README/README.environment
@@ -1679,6 +1679,12 @@ range is 0 .. 0.05 (which will be very thick lines, I assure you).
 This variable was introduced in March 2015 for Corianne (if there is
 such a person).
 
+----------------------------------
+Variable: AFNI_CROSSHAIR_GAP
+----------------------------------
+This numeric variable lets you set the gap between the image viewer crosshairs.
+The default value is 5 voxels. Allowable range is from -1 (closed) to 19 voxels.
+
 -----------------------------
 Variable: AFNI_CROSSHAIRS_OFF
 -----------------------------

--- a/src/afni_history_dglen.c
+++ b/src/afni_history_dglen.c
@@ -53,6 +53,10 @@
 
 
 afni_history_struct dglen_history[] = {
+{ 15, SEP, 2025, DRG, "afni",
+     MICRO, TYPE_NEW_ENV,
+    "AFNI_XHAIR_GAP can be set to specify crosshair gap"
+},
 { 19, AUG, 2025, DRG, "3dXYZcat",
      MICRO, TYPE_BUG_FIX,
     "3dXYZcat generated extra empty volume in X direction"

--- a/src/afni_widg.c
+++ b/src/afni_widg.c
@@ -8209,7 +8209,7 @@ static int get_crosshair_gap()
       tempgap = (int) AFNI_numenv_def("AFNI_CROSSHAIR_GAP",
                                       (double) INIT_crosshair_gap);
       /* make sure it's legit. For now limit to -1 voxels (closed) to max=19*/
-      if((tempgap>=-1) && (tempgap<MAX_GAP))
+      if((tempgap>=-1) && (tempgap<=MAX_GAP))
          crosshair_gap =tempgap;
       else
          crosshair_gap = INIT_crosshair_gap ; /* default=5 pbar_color_defs.c */

--- a/src/afni_widg.c
+++ b/src/afni_widg.c
@@ -338,6 +338,10 @@ void AFNI_make_wid3 (Three_D_View *) ;
 static Widget wtemp ;
 static char jumpstring[128];                  /* 13 Jun 2014 */
 
+static int get_crosshair_gap();               /* 15 Sep 2025 */
+static int crosshair_gap = -2;
+static int MAX_GAP = 19;
+
 /*--------------------------------------------------------------------*/
 
 void AFNI_make_widgets( Three_D_View *im3d )
@@ -6431,7 +6435,7 @@ ENTRY("new_AFNI_controller") ;
 
    last_color = im3d->dc->ovc->ncol_ov - 1 ;
 
-   im3d->vinfo->crosshair_gap     = INIT_crosshair_gap ;
+   im3d->vinfo->crosshair_gap     = get_crosshair_gap();
    im3d->vinfo->crosshair_gap_old = 0 ;
    im3d->vinfo->crosshair_visible = True ;                /* show crosshairs */
    im3d->vinfo->crosshair_ovcolor = MIN(last_color,INIT_crosshair_color) ;
@@ -8190,4 +8194,27 @@ void reset_mnito(struct Three_D_View *im3d)
 
    MCW_set_widget_label( im3d->vwid->imag->pop_mnito_pb, jumpstring ) ;
    XtManageChild( im3d->vwid->imag->pop_mnito_pb ) ;
+}
+
+/* set the size of the gap in the crosshairs */
+static int get_crosshair_gap()
+{
+   int tempgap;
+
+   if(crosshair_gap>=-1)
+      return(crosshair_gap);
+   else {
+      /* get crosshair gap from environment if it exists - 
+         catch not set because we want to distinguish 0's */
+      tempgap = (int) AFNI_numenv_def("AFNI_CROSSHAIR_GAP",
+                                      (double) INIT_crosshair_gap);
+      /* make sure it's legit. For now limit to -1 voxels (closed) to max=19*/
+      if((tempgap>=-1) && (tempgap<MAX_GAP))
+         crosshair_gap =tempgap;
+      else
+         crosshair_gap = INIT_crosshair_gap ; /* default=5 in pbardefs */
+   }
+
+   return(crosshair_gap);
+
 }

--- a/src/afni_widg.c
+++ b/src/afni_widg.c
@@ -8212,7 +8212,7 @@ static int get_crosshair_gap()
       if((tempgap>=-1) && (tempgap<MAX_GAP))
          crosshair_gap =tempgap;
       else
-         crosshair_gap = INIT_crosshair_gap ; /* default=5 in pbardefs */
+         crosshair_gap = INIT_crosshair_gap ; /* default=5 pbar_color_defs.c */
    }
 
    return(crosshair_gap);


### PR DESCRIPTION
Crosshair gap size can be set by default with an AFNI environment variable, AFNI_CROSSHAIR_GAP. Set this in the shell environment, on the command line via "-DAFNI_CROSSHAIR_GAP=nn" or in the .afnirc configuration file. Allowable values are between -1 and 19.

In response to this request on the AFNI messageboard:
https://discuss.afni.nimh.nih.gov/t/crosshair-color-and-gap-size-env-variable/3702

The current behavior is kept where new controllers take the default initial value rather than inheriting the gap size from the current controller. Should new controllers take their value from the previous controller setting, encouraging the same gap across all controllers, or take their initial value from the default (which can now come from the environment)? If a user updates the gap from 5 to 12, should a new controller be 12 or 5? Should gap size be automatically propagated across all controllers, so that if a user changes the gap size in one controller, the gap size changes in all controllers?