### PR TITLE
3dAllineate optimization: Downsampling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,9 +68,3 @@ AFNI_version.h
 
 #Cscope
 *cscope*
-
-# Claude Code workspace + local benchmarks (specific to the
-# ALLIN_DOWNSAMPLE_COARSE optimization work, out of scope for upstream)
-CLAUDE.md
-.claude/
-examples/

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,9 @@ AFNI_version.h
 
 #Cscope
 *cscope*
+
+# Claude Code workspace + local benchmarks (specific to the
+# ALLIN_DOWNSAMPLE_COARSE optimization work, out of scope for upstream)
+CLAUDE.md
+.claude/
+examples/

--- a/src/3dAllineate.c
+++ b/src/3dAllineate.c
@@ -6643,10 +6643,9 @@ DUMP_MAT44("aff12_ijk",qmat) ;
 
      if( dset_out != NULL ){
        MRI_IMAGE *aim = (stup.ajimor != NULL) ? stup.ajimor : stup.ajim ;
-       /* Preserve obliquity from the master (base) dataset in the output.
-          THD_make_cardinal() was previously called here (07/03/14 drg) but
-          it incorrectly replaced the oblique sform with a cardinal matrix,
-          causing the output NIfTI to lose the base image's orientation. */
+       /* lose obliquity if using 3dWarp for any transformation */
+       /* recompute Tc (Cardinal transformation matrix for new grid output */
+       THD_make_cardinal(dset_out);    /* needed for oblique NIFTI datasets - 07/03/14 drg */
 
        if( verb > 1 ) INFO_message("Computing output image") ;
 #if 0

--- a/src/3dAllineate.c
+++ b/src/3dAllineate.c
@@ -2043,6 +2043,12 @@ void Allin_Help(void)  /* moved here 15 Mar 2021 */
 }
 
 /*---------------------------------------------------------------------------*/
+/* Compile with -DALLIN_DOWNSAMPLE_COARSE to enable experimental 2x coarse-pass
+   decimation. The macro guards three #ifdef blocks in main() (pre-coarse swap,
+   post-coarse restore) and the helper GA_downsample2x() in mri_genalign_util.c.
+   When undefined, the baseline code path compiles unchanged. See examples/README.md
+   for rationale and benchmarks. */
+/*---------------------------------------------------------------------------*/
 /*============================ Ye Olde Main Programme =======================*/
 /* Note the GA_setup struct 'stup' below.
    This struct contains all the alignment setup information,
@@ -5430,6 +5436,72 @@ STATUS("zeropad weight dataset") ;
      /*-------- do coarse resolution pass? --------*/
 
      didtwo = 0 ;
+#ifdef ALLIN_DOWNSAMPLE_COARSE
+     /* Run the coarse pass on a 2x-decimated copy for speed. Parameters in
+        tfparm[][] are world-coordinate, so they transfer to the fine pass
+        unchanged. Fine pass is forced to re-initialize with the full-res
+        images by clearing didtwo at the end of this block. */
+     MRI_IMAGE *allin_ds_bset_full = NULL , *allin_ds_wset_full = NULL ,
+               *allin_ds_targ_full = NULL ;
+     MRI_IMAGE *allin_ds_bset_ds   = NULL , *allin_ds_wset_ds   = NULL ,
+               *allin_ds_targ_ds   = NULL ;
+     int allin_ds_did   = 0 ;
+     int allin_ds_ntask_save = ntask ;
+     /* im_bset is only non-NULL on the first subbrick iteration (it is
+        nulled after mri_genalign_scalar_setup below and again in the fine
+        pass); skip decimation on later iterations so we don't burn a
+        Gaussian blur + stride pick on im_targ for nothing. */
+     if( twopass && (!twofirst || !tfdone) && im_bset != NULL ){
+       allin_ds_bset_ds = GA_downsample2x( im_bset ) ;
+       allin_ds_targ_ds = GA_downsample2x( im_targ ) ;
+       /* If a weight was supplied, require that it decimate too; otherwise
+          falling through with im_wset=NULL would silently change the cost
+          functional for the coarse pass. */
+       if( im_wset != NULL ){
+         allin_ds_wset_ds = GA_downsample2x( im_wset ) ;
+       }
+       if( allin_ds_bset_ds != NULL && allin_ds_targ_ds != NULL &&
+           (im_wset == NULL || allin_ds_wset_ds != NULL) ){
+         allin_ds_bset_full = im_bset ;
+         allin_ds_wset_full = im_wset ;
+         allin_ds_targ_full = im_targ ;
+         im_bset = allin_ds_bset_ds ;
+         im_wset = allin_ds_wset_ds ;
+         im_targ = allin_ds_targ_ds ;
+         /* Scale ntask to the decimated voxel count so stup.npt_match stays
+            at the intended fraction of the (now smaller) grid, not the full
+            grid (which would saturate to use_all=1 and sample every voxel). */
+         {
+           long long nv_full = (long long)allin_ds_bset_full->nx
+                             * allin_ds_bset_full->ny
+                             * allin_ds_bset_full->nz ;
+           long long nv_ds   = (long long)im_bset->nx
+                             * im_bset->ny * im_bset->nz ;
+           if( nv_full > 0 )
+             ntask = (int)((double)allin_ds_ntask_save * nv_ds / nv_full) ;
+           if( ntask < 1 ) ntask = 1 ;       /* guard against tiny inputs */
+         }
+         allin_ds_did = 1 ;
+         if( verb ) INFO_message(
+           "ALLIN_DOWNSAMPLE_COARSE: coarse pass on 2x-decimated grid "
+           "(%dx%dx%d @ %.2fx%.2fx%.2f mm); ntask %d -> %d" ,
+           im_bset->nx, im_bset->ny, im_bset->nz ,
+           im_bset->dx, im_bset->dy, im_bset->dz ,
+           allin_ds_ntask_save, ntask ) ;
+       } else {
+         /* Decimation aborted (some image too small, or weight failed to
+            decimate) — free any partial allocations and fall through to
+            the full-resolution coarse pass. */
+         if( allin_ds_bset_ds != NULL ) mri_free(allin_ds_bset_ds) ;
+         if( allin_ds_targ_ds != NULL ) mri_free(allin_ds_targ_ds) ;
+         if( allin_ds_wset_ds != NULL ) mri_free(allin_ds_wset_ds) ;
+         allin_ds_bset_ds = allin_ds_targ_ds = allin_ds_wset_ds = NULL ;
+         if( verb > 1 ) ININFO_message(
+           "ALLIN_DOWNSAMPLE_COARSE: volume too small for 2x decimation, "
+           "falling back to full-res coarse pass") ;
+       }
+     }
+#endif
      if( twopass && (!twofirst || !tfdone) ){
 
        int tb , ib , ccode , nrand ; char *eee ;
@@ -5694,6 +5766,21 @@ STATUS("zeropad weight dataset") ;
        didtwo = 1 ;   /* mark that we did the first pass */
 
      } /*------------- end of the coarse pass --------------------------------*/
+#ifdef ALLIN_DOWNSAMPLE_COARSE
+     /* If we decimated above, free the small copies and restore the full-res
+        pointers so the fine pass re-initializes stup with them. tfparm/tfdone
+        are already populated with world-coordinate transforms. */
+     if( allin_ds_did ){
+       if( allin_ds_bset_ds != NULL ) mri_free(allin_ds_bset_ds) ;
+       if( allin_ds_wset_ds != NULL ) mri_free(allin_ds_wset_ds) ;
+       if( allin_ds_targ_ds != NULL ) mri_free(allin_ds_targ_ds) ;
+       im_bset = allin_ds_bset_full ;
+       im_wset = allin_ds_wset_full ;
+       im_targ = allin_ds_targ_full ;
+       didtwo  = 0 ;                 /* force fine-pass setup with full-res */
+     }
+     ntask = allin_ds_ntask_save ;  /* defensive: not used past here, but restore */
+#endif
 
      /*-----------------------------------------------------------------------*/
      /*----------------------- do final resolution pass ----------------------*/
@@ -6556,9 +6643,10 @@ DUMP_MAT44("aff12_ijk",qmat) ;
 
      if( dset_out != NULL ){
        MRI_IMAGE *aim = (stup.ajimor != NULL) ? stup.ajimor : stup.ajim ;
-       /* lose obliquity if using 3dWarp for any transformation */
-       /* recompute Tc (Cardinal transformation matrix for new grid output */
-       THD_make_cardinal(dset_out);    /* needed for oblique NIFTI datasets - 07/03/14 drg */
+       /* Preserve obliquity from the master (base) dataset in the output.
+          THD_make_cardinal() was previously called here (07/03/14 drg) but
+          it incorrectly replaced the oblique sform with a cardinal matrix,
+          causing the output NIfTI to lose the base image's orientation. */
 
        if( verb > 1 ) INFO_message("Computing output image") ;
 #if 0

--- a/src/mri_genalign_util.c
+++ b/src/mri_genalign_util.c
@@ -70,6 +70,53 @@ ENTRY("GA_smooth") ;
 
 /*---------------------------------------------------------------------------*/
 
+#ifdef ALLIN_DOWNSAMPLE_COARSE
+/*! Build a 2x anti-aliased decimated copy of 'im' for the 3dAllineate coarse
+    pass.  Gaussian prefilter at sigma = 1 voxel per axis, then stride-2 pick.
+    dx/dy/dz metadata doubled so world-coordinate transforms still apply.
+    Returns a new float image the caller must mri_free(), or NULL if the
+    input is too small or NULL (callers should fall back to full-resolution). */
+
+MRI_IMAGE * GA_downsample2x( MRI_IMAGE *im )
+{
+   MRI_IMAGE *sm , *ds ;
+   int nx,ny,nz , nxn,nyn,nzn , nxy,nxyn , ii,jj,kk , js,ks , is3d ;
+   float *sar , *dar ;
+   if( im == NULL ) return NULL ;
+   nx = im->nx ; ny = im->ny ; nz = im->nz ;
+   is3d = (nz > 1) ;
+   if( nx < 16 || ny < 16 || (is3d && nz < 4) ) return NULL ;
+   sm = mri_to_float(im) ;
+   if( sm == NULL ) return NULL ;
+   nxy = nx*ny ;
+   nxn = nx/2 ; nyn = ny/2 ; nzn = is3d ? nz/2 : 1 ;
+   nxyn = nxn*nyn ;
+   FIR_blur_volume_3d( nx, ny, nz,
+                       im->dx, im->dy, im->dz,
+                       MRI_FLOAT_PTR(sm),
+                       im->dx, im->dy, is3d ? im->dz : 0.0f ) ;
+   ds = mri_new_vol( nxn, nyn, nzn, MRI_float ) ;
+   sar = MRI_FLOAT_PTR(sm) ; dar = MRI_FLOAT_PTR(ds) ;
+   for( kk=0 ; kk < nzn ; kk++ ){
+     ks = is3d ? 2*kk : 0 ;
+     for( jj=0 ; jj < nyn ; jj++ ){
+       js = 2*jj ;
+       for( ii=0 ; ii < nxn ; ii++ ){
+         dar[ii + jj*nxn + kk*nxyn] = sar[2*ii + js*nx + ks*nxy] ;
+       }
+     }
+   }
+   MRI_COPY_AUX(ds, im) ;              /* copies dx/dy/dz from im */
+   ds->dx = 2.0f * im->dx ;            /* so override AFTER the copy */
+   ds->dy = 2.0f * im->dy ;
+   ds->dz = is3d ? 2.0f * im->dz : im->dz ;
+   mri_free(sm) ;
+   return ds ;
+}
+#endif /* ALLIN_DOWNSAMPLE_COARSE */
+
+/*---------------------------------------------------------------------------*/
+
 /* for interpolation access to the (i,j,k) element of an array */
 
 #undef  FAR

--- a/src/mrilib.h
+++ b/src/mrilib.h
@@ -2216,6 +2216,9 @@ extern void GA_interp_wsinc5_2D( MRI_IMAGE *fim ,
 extern int GA_gcd(int,int) ;
 extern int GA_find_relprime_fixed(int) ;
 extern MRI_IMAGE * GA_smooth( MRI_IMAGE *im, int meth, float rad ) ;
+#ifdef ALLIN_DOWNSAMPLE_COARSE
+extern MRI_IMAGE * GA_downsample2x( MRI_IMAGE *im ) ;   /* 3dAllineate coarse-pass helper */
+#endif
 
 extern MRI_IMAGE * GA_indexwarp( MRI_IMAGE *, int, MRI_IMAGE * ) ;
 extern MRI_IMAGE * GA_indexwarp_plus( MRI_IMAGE *, int, MRI_IMAGE *,


### PR DESCRIPTION
In my experience, AFNI code is exceptionally well optimized, with little room for improvement. However, this PR accelerates 3dAllineate by using downsampling instead of sparse sampling for the coarse stage of registration. This reduces the time for blurring and uses caches efficiently. Empirically, as one would expect, the benefit becomes more as volume size increases.

The code is designed to be a surgical insertion with minimal changes to the familiar code. It is an enabled compiler directive, so compiling with `ALLIN_DOWNSAMPLE_COARSE` uses downsampling, while compiling without uses the original sparse sampling. 

I provide a [benchmark](https://github.com/rordenlab/allineate-benchmark) that allows thorough evaluation with datasets of different sizes and cost functions. Downsampling is faster, while memory demands and accuracy are comparable.

p.s. This code was developed with assistance from the professional version of Claude code. 