### PR TITLE
adding RSA-specific plots to 1dplot.py

### DIFF
--- a/src/python_scripts/afnipy/lib_apqc_io.py
+++ b/src/python_scripts/afnipy/lib_apqc_io.py
@@ -337,6 +337,13 @@ COMMAND OPTIONS ~1~
               :add vertical reference lines to histogram, scatter or line
                plots.  For example, use '-vline 0' to mark zero.
 
+-vline_hl VV LABEL
+              :add a highlighted vertical reference line to histogram,
+               scatter or line plots: drawn in a distinct color and added
+               to the legend under LABEL.  For example, use
+               '-vline_hl 0.42 "mean 0.42"' to call out the mean.  May be
+               repeated.
+
 -scatter      :draw points rather than lines.  This is mainly useful with
                '-xfile ..' to provide the x-values.
 
@@ -732,6 +739,7 @@ class figplobj:
         self.histwidth   = DEF_histwidth
         self.hist_density = DEF_hist_density
         self.vlines      = []
+        self.vlines_hl   = []
         self.heat_matrix = []
         self.heat_cmap   = DEF_heat_cmap
         self.zerocenter  = False
@@ -765,6 +773,9 @@ class figplobj:
 
     def set_vlines(self, ll):
         self.vlines = ll
+
+    def set_vlines_hl(self, ll):
+        self.vlines_hl = ll
 
     def set_heat_opts(self, mat, cmap, zcen):
         self.heat_matrix = mat
@@ -1109,6 +1120,7 @@ class apqc_1dplot_opts:
         self.histwidth  = DEF_histwidth
         self.hist_density = DEF_hist_density
         self.vlines     = []
+        self.vlines_hl  = []
         self.heat_matrix = []
         self.heat_cmap  = DEF_heat_cmap
         self.zerocenter = False
@@ -1208,6 +1220,9 @@ class apqc_1dplot_opts:
 
     def add_vline(self, c):
         self.vlines.append(float(c))
+
+    def add_vline_hl(self, val, label):
+        self.vlines_hl.append((float(val), label))
 
     def set_heat_cmap(self, c):
         self.heat_cmap = c
@@ -1912,6 +1927,14 @@ def parse_1dplot_args(full_argv):
                     break
             if not(count):
                 ARG_missing_arg(argv[i])
+
+        elif argv[i] == "-vline_hl":
+            if i+2 >= Narg:
+                ARG_missing_arg(argv[i])
+            val = argv[i+1]
+            label = argv[i+2]
+            i+= 2
+            iopts.add_vline_hl(val, label)
 
         elif argv[i] == "-scatter":
             iopts.set_scatter(True)

--- a/src/python_scripts/afnipy/lib_apqc_io.py
+++ b/src/python_scripts/afnipy/lib_apqc_io.py
@@ -151,6 +151,11 @@ DEF_margin_on     = True
 DEF_bplot_view    = ""  # vals: ["BC_ONLY", "BC_AC"]
 DEF_boxplot_ycen  = False
 DEF_censor_on     = False
+DEF_plot_kind     = 'line'
+DEF_histbin       = 0
+DEF_histwidth     = 0.0
+DEF_hist_density  = False
+DEF_heat_cmap     = 'viridis'
 
 # mostly from: plt.cm.get_cmap('Set1') and plt.cm.get_cmap('tab10')
 DEF_color_table = [
@@ -314,6 +319,41 @@ COMMAND OPTIONS ~1~
                '-yfiles_pm ..' is used, you can use this option to expand
                those limits by the min and max of the extra error-bounded
                space.
+
+-histogram    :draw a binned histogram of each input column, rather than
+               a line plot.  This is distinct from the older 1dplot
+               "-hist" step-line style.
+
+-histbin NN   :set the number of bins to use with '-histogram'.  By default,
+               a simple sqrt(N) rule is used, with a minimum of 8 bins.
+
+-histwidth WW :set the bin width to use with '-histogram'.  This is an
+               alternative to '-histbin ..'.
+
+-density      :with '-histogram', normalize the histogram to show density
+               instead of counts.
+
+-vline VV1 VV2 ...
+              :add vertical reference lines to histogram, scatter or line
+               plots.  For example, use '-vline 0' to mark zero.
+
+-scatter      :draw points rather than lines.  This is mainly useful with
+               '-xfile ..' to provide the x-values.
+
+-diagonal     :with '-scatter', add a dashed y=x reference line and use
+               equal x/y scaling.
+
+-heat         :draw the single input as a square matrix heatmap.  This mode
+               is meant for numeric 1D matrix files, such as RDMs.
+
+-cbar CMAP    :with '-heat', set the color map.  Matplotlib colormap names
+               are accepted, as are a couple AFNI-style names such as
+               'Reds_and_Blues' and 'Reds_and_Blues_Inv'.
+
+-zerocenter   :with '-heat', make the color range symmetric around zero.
+
+-reorder RR   :with '-heat', read one column of 0-based row/column indices
+               from RR, and apply the same permutation to rows and columns.
 
 -xfile   XX   :one way to input x-values explicitly: as a "1D" file XX, a
                containing a single file of numbers.  If no xfile is 
@@ -687,6 +727,18 @@ class figplobj:
         self.legend_on    = False
         self.ylim_use_pm  = False
         self.ylabels_maxlen = None
+        self.plot_kind   = DEF_plot_kind
+        self.histbin     = DEF_histbin
+        self.histwidth   = DEF_histwidth
+        self.hist_density = DEF_hist_density
+        self.vlines      = []
+        self.heat_matrix = []
+        self.heat_cmap   = DEF_heat_cmap
+        self.zerocenter  = False
+        self.reorder_file = ''
+        self.reorder     = []
+        self.scatter_on  = False
+        self.diagonal    = False
 
 
     # ----------------------------
@@ -702,6 +754,28 @@ class figplobj:
 
     def set_ylabels_maxlen(self, c):
         self.ylabels_maxlen = c
+
+    def set_plot_kind(self, c):
+        self.plot_kind = c
+
+    def set_hist_opts(self, nbins, width, density):
+        self.histbin      = nbins
+        self.histwidth    = width
+        self.hist_density = density
+
+    def set_vlines(self, ll):
+        self.vlines = ll
+
+    def set_heat_opts(self, mat, cmap, zcen):
+        self.heat_matrix = mat
+        self.heat_cmap   = cmap
+        self.zerocenter  = zcen
+
+    def set_scatter(self, c):
+        self.scatter_on = c
+
+    def set_diagonal(self, c):
+        self.diagonal = c
 
     def set_boxplot(self, c):
         self.boxplot_on = c
@@ -1030,6 +1104,18 @@ class apqc_1dplot_opts:
         self.ndsets = -1
         self.all_ymin = 0
         self.all_ymax = 0
+        self.plot_kind  = DEF_plot_kind
+        self.histbin    = DEF_histbin
+        self.histwidth  = DEF_histwidth
+        self.hist_density = DEF_hist_density
+        self.vlines     = []
+        self.heat_matrix = []
+        self.heat_cmap  = DEF_heat_cmap
+        self.zerocenter = False
+        self.reorder_file = ''
+        self.reorder    = []
+        self.scatter_on = False
+        self.diagonal   = False
 
     # ----------- req -----------------
 
@@ -1051,6 +1137,9 @@ class apqc_1dplot_opts:
         if self.infiles == []:
             print("missing: infiles")
             MISS+=1
+        if self.plot_kind == 'heat' and len(self.infiles) != 1:
+            print("missing: heat plots require exactly one infile")
+            MISS+=1
         if self.prefix == "":
             print("missing: prefix")
             MISS+=1
@@ -1060,6 +1149,26 @@ class apqc_1dplot_opts:
         CONFLICTS = 0
         if self.boxplot_on and self.one_graph :
             print("conflict: using both '-boxplot_on' and '-onegraph'")
+            CONFLICTS+=1
+        if self.plot_kind == 'heat':
+            if self.boxplot_on or self.one_graph or self.yfile_pm:
+                print("conflict: '-heat' with boxplot/one_graph/yfiles_pm")
+                CONFLICTS+=1
+            if self.xfile or self.xvals:
+                print("conflict: '-heat' with x-axis input")
+                CONFLICTS+=1
+            if self.censor_on or self.censor_hline or self.patch_arr:
+                print("conflict: '-heat' with censor/patch options")
+                CONFLICTS+=1
+        if self.plot_kind == 'histogram':
+            if self.boxplot_on or self.yfile_pm:
+                print("conflict: '-histogram' with boxplot/yfiles_pm")
+                CONFLICTS+=1
+        if self.histbin and self.histwidth:
+            print("conflict: using both '-histbin' and '-histwidth'")
+            CONFLICTS+=1
+        if self.diagonal and self.plot_kind != 'scatter':
+            print("conflict: '-diagonal' currently requires '-scatter'")
             CONFLICTS+=1
         return CONFLICTS
 
@@ -1080,6 +1189,83 @@ class apqc_1dplot_opts:
 
     def set_bkgd_color(self, c):
         self.bkgd_color = c
+
+    def set_plot_kind(self, c):
+        self.plot_kind = c
+
+    def set_histbin(self, c):
+        self.histbin = int(c)
+        if self.histbin < 1:
+            sys.exit("** ERROR: '-histbin' must be positive")
+
+    def set_histwidth(self, c):
+        self.histwidth = float(c)
+        if self.histwidth <= 0:
+            sys.exit("** ERROR: '-histwidth' must be positive")
+
+    def set_hist_density(self, c):
+        self.hist_density = c
+
+    def add_vline(self, c):
+        self.vlines.append(float(c))
+
+    def set_heat_cmap(self, c):
+        self.heat_cmap = c
+
+    def set_zerocenter(self, c):
+        self.zerocenter = c
+
+    def set_reorder_file(self, fff):
+        self.reorder_file = fff
+
+    def set_scatter(self, c):
+        self.scatter_on = c
+        if c:
+            self.set_plot_kind('scatter')
+
+    def set_diagonal(self, c):
+        self.diagonal = c
+
+    def read_heat_matrix(self):
+        dat = LAD.Afni1D(self.infiles[0])
+        if dat.nt < 1 or dat.nvec < 1:
+            sys.exit("** ERROR: empty matrix for '-heat': {}".format(
+                     self.infiles[0]))
+        if dat.nt != dat.nvec:
+            sys.exit("** ERROR: '-heat' requires a square matrix; have "
+                     "{} rows and {} cols in {}".format(dat.nt, dat.nvec,
+                                                        self.infiles[0]))
+        mat = []
+        for r in range(dat.nt):
+            mat.append([dat.mat[c][r] for c in range(dat.nvec)])
+        self.heat_matrix = mat
+
+    def read_reorder_file(self):
+        if not(self.reorder_file):
+            return
+        dat = LAD.Afni1D(self.reorder_file)
+        if dat.nvec != 1:
+            sys.exit("** ERROR: '-reorder' file must have exactly one column")
+        order = []
+        for val in dat.mat[0]:
+            ii = int(val)
+            if ii != val:
+                sys.exit("** ERROR: '-reorder' values must be integers")
+            order.append(ii)
+        if len(order) != len(self.heat_matrix):
+            sys.exit("** ERROR: '-reorder' length {} does not match matrix "
+                     "size {}".format(len(order), len(self.heat_matrix)))
+        if sorted(order) != list(range(len(order))):
+            sys.exit("** ERROR: '-reorder' must be a permutation of 0..N-1")
+        self.reorder = order
+
+    def apply_heat_reorder(self):
+        if not(self.reorder):
+            return
+        mat = []
+        for r in self.reorder:
+            mat.append([self.heat_matrix[r][c] for c in self.reorder])
+        self.heat_matrix = mat
 
     # [PT: Jan 15, 2019] e.g., for multiple dsets, concatenated runs;
     # just a list that must be in correct order
@@ -1692,6 +1878,64 @@ def parse_1dplot_args(full_argv):
 
         elif argv[i] == "-ylim_use_pm":
             iopts.ylim_use_pm = True
+
+        elif argv[i] == "-histogram":
+            iopts.set_plot_kind('histogram')
+
+        elif argv[i] == "-histbin":
+            if i >= Narg:
+                ARG_missing_arg(argv[i])
+            i+= 1
+            iopts.set_histbin(argv[i])
+
+        elif argv[i] == "-histwidth":
+            if i >= Narg:
+                ARG_missing_arg(argv[i])
+            i+= 1
+            iopts.set_histwidth(argv[i])
+
+        elif argv[i] == "-density":
+            iopts.set_hist_density(True)
+
+        elif argv[i] == "-vline":
+            count = 0
+            if i >= Narg:
+                ARG_missing_arg(argv[i])
+            i+= 1
+            while i < Narg:
+                if not(all_opts.__contains__(argv[i])):
+                    iopts.add_vline(argv[i])
+                    count+=1
+                    i+=1
+                else:
+                    i-=1
+                    break
+            if not(count):
+                ARG_missing_arg(argv[i])
+
+        elif argv[i] == "-scatter":
+            iopts.set_scatter(True)
+
+        elif argv[i] == "-diagonal":
+            iopts.set_diagonal(True)
+
+        elif argv[i] == "-heat":
+            iopts.set_plot_kind('heat')
+
+        elif argv[i] == "-cbar":
+            if i >= Narg:
+                ARG_missing_arg(argv[i])
+            i+= 1
+            iopts.set_heat_cmap(argv[i])
+
+        elif argv[i] == "-zerocenter":
+            iopts.set_zerocenter(True)
+
+        elif argv[i] == "-reorder":
+            if i >= Narg:
+                ARG_missing_arg(argv[i])
+            i+= 1
+            iopts.set_reorder_file(argv[i])
 
         elif argv[i] == "-ylabels":
             count = 0

--- a/src/python_scripts/afnipy/lib_plot_1D.py
+++ b/src/python_scripts/afnipy/lib_plot_1D.py
@@ -370,6 +370,9 @@ lots of individual subject 'ss' instances of the subplobj object.
         for vv in bf.vlines:
             pp.axvline(x=vv, c='0.2', ls='--', lw=1)
 
+        for vv, lbl in bf.vlines_hl:
+            pp.axvline(x=vv, color='#c44e52', lw=1.5, label=lbl)
+
         pp.set_xlabel(ss.xlabel, fontsize=bf.fontsize)
 
         if bf.ylabels_maxlen :
@@ -408,7 +411,7 @@ lots of individual subject 'ss' instances of the subplobj object.
             # suptitle
             pp.set_title(bf.title, fontsize=bf.fontsize)
 
-        if bf.legend_on :
+        if bf.legend_on or bf.vlines_hl:
             pp.legend(loc=ss.legloc)
 
 
@@ -564,6 +567,9 @@ def make_1dplot_histogram_figure(bf):
         for vv in bf.vlines:
             pp.axvline(x=vv, c='0.2', ls='--', lw=1)
 
+        for vv, lbl in bf.vlines_hl:
+            pp.axvline(x=vv, color='#c44e52', lw=1.5, label=lbl)
+
         title = ''
         if bf.title and not(i):
             title = bf.title
@@ -590,7 +596,7 @@ def make_1dplot_histogram_figure(bf):
             pp.spines['top'   ].set_color('0.5')
             pp.spines['left'  ].set_color('0.5')
             pp.spines['right' ].set_color('0.5')
-        if bf.legend_on:
+        if bf.legend_on or bf.vlines_hl:
             pp.legend(loc=ss.legloc)
         print("++ Plotting histogram: {}".format(ss.ylabel))
 
@@ -719,6 +725,7 @@ def populate_1dplot_fig(iopts):
     bigfig.set_plot_kind( iopts.plot_kind )
     bigfig.set_hist_opts( iopts.histbin, iopts.histwidth, iopts.hist_density )
     bigfig.set_vlines( iopts.vlines )
+    bigfig.set_vlines_hl( iopts.vlines_hl )
     bigfig.set_heat_opts( iopts.heat_matrix, iopts.heat_cmap,
                           iopts.zerocenter )
     bigfig.set_scatter( iopts.scatter_on )

--- a/src/python_scripts/afnipy/lib_plot_1D.py
+++ b/src/python_scripts/afnipy/lib_plot_1D.py
@@ -250,6 +250,11 @@ lots of individual subject 'ss' instances of the subplobj object.
 
     '''
 
+    if bf.plot_kind == 'histogram':
+        return make_1dplot_histogram_figure(bf)
+    elif bf.plot_kind == 'heat':
+        return make_1dplot_heat_figure(bf)
+
     fff = plt.figure(bf.title, figsize=bf.figsize)
 
     rcParams['font.family'] = bf.fontfamily
@@ -331,10 +336,18 @@ lots of individual subject 'ss' instances of the subplobj object.
         # number of points.
         #if not(bf.margin_on) :
         #    pp.axis('off')
-        sp = pp.plot( ss.x, ss.y, 
-                      color = ss.color,
-                      lw=calc_lw_from_npts(ss.npts),
-                      label=ss.leglabel )
+        if bf.scatter_on:
+            sp = pp.scatter( ss.x, ss.y,
+                             color = ss.color,
+                             s=14,
+                             alpha=0.7,
+                             edgecolors='none',
+                             label=ss.leglabel )
+        else:
+            sp = pp.plot( ss.x, ss.y,
+                          color = ss.color,
+                          lw=calc_lw_from_npts(ss.npts),
+                          label=ss.leglabel )
 
         # if using yrange: can have a semitransparent filled area
         if len(ss.yrantop) :
@@ -345,6 +358,17 @@ lots of individual subject 'ss' instances of the subplobj object.
 
         pp.set_xlim(ss.xlim)
         pp.set_ylim(ss.ylim)
+
+        if bf.diagonal:
+            vmin = min(min(ss.x), min(ss.y))
+            vmax = max(max(ss.x), max(ss.y))
+            pp.plot([vmin, vmax], [vmin, vmax], color='0.2', ls='--', lw=1)
+            pp.set_xlim([vmin, vmax])
+            pp.set_ylim([vmin, vmax])
+            pp.set_aspect('equal')
+
+        for vv in bf.vlines:
+            pp.axvline(x=vv, c='0.2', ls='--', lw=1)
 
         pp.set_xlabel(ss.xlabel, fontsize=bf.fontsize)
 
@@ -509,6 +533,151 @@ lots of individual subject 'ss' instances of the subplobj object.
 
 # ---------------------------------------------------------------------------
 
+def make_1dplot_histogram_figure(bf):
+    '''Make binned histogram(s), one per input column unless one_graph is on.'''
+
+    rcParams['font.family'] = bf.fontfamily
+    rcParams['axes.linewidth'] = 0.5
+
+    if bf.ngraph > 1:
+        a, subpl = plt.subplots( bf.ngraph, 1, figsize=bf.figsize )
+    else:
+        a, subpl = plt.subplots( 1, 1, figsize=bf.figsize )
+
+    for i in range(bf.nsub):
+        ss = bf.all_subs[i]
+
+        if bf.ngraph > 1:
+            pp = subpl[i]
+        else:
+            pp = subpl
+
+        bins = get_hist_bins(ss.y, bf.histbin, bf.histwidth)
+        pp.hist( ss.y,
+                 bins=bins,
+                 density=bf.hist_density,
+                 color=ss.color,
+                 alpha=0.75,
+                 edgecolor='white',
+                 label=ss.leglabel )
+
+        for vv in bf.vlines:
+            pp.axvline(x=vv, c='0.2', ls='--', lw=1)
+
+        title = ''
+        if bf.title and not(i):
+            title = bf.title
+        elif ss.ylabel:
+            title = ss.ylabel
+        if title:
+            pp.set_title(title, fontsize=bf.fontsize)
+
+        if bf.ngraph > 1:
+            if i < bf.nsub - 1:
+                pp.set_xlabel("")
+            else:
+                pp.set_xlabel(ss.xlabel, fontsize=bf.fontsize)
+        else:
+            pp.set_xlabel(ss.xlabel, fontsize=bf.fontsize)
+
+        pp.set_ylabel('density' if bf.hist_density else 'count',
+                      fontsize=bf.fontsize)
+
+        pp.tick_params( axis='both', which='major', direction='in',
+                        color='0.5', bottom=True, left=True, right=True )
+        if bf.margin_on:
+            pp.spines['bottom'].set_color('0.5')
+            pp.spines['top'   ].set_color('0.5')
+            pp.spines['left'  ].set_color('0.5')
+            pp.spines['right' ].set_color('0.5')
+        if bf.legend_on:
+            pp.legend(loc=ss.legloc)
+        print("++ Plotting histogram: {}".format(ss.ylabel))
+
+    save_1dplot_pyplot(bf)
+    return 0
+
+# ---------------------------------------------------------------------------
+
+def get_hist_bins(vals, nbins=0, width=0.0):
+    if width:
+        vmin = min(vals)
+        vmax = max(vals)
+        if vmin == vmax:
+            return [vmin - 0.5 * width, vmax + 0.5 * width]
+        bins = []
+        vv = vmin
+        while vv <= vmax:
+            bins.append(vv)
+            vv+= width
+        if bins[-1] < vmax:
+            bins.append(vmax)
+        elif len(bins) == 1:
+            bins.append(vmax)
+        return bins
+    if nbins:
+        return nbins
+    return max(8, int(len(vals)**0.5))
+
+# ---------------------------------------------------------------------------
+
+def make_1dplot_heat_figure(bf):
+    '''Make a square matrix heatmap.'''
+
+    rcParams['font.family'] = bf.fontfamily
+    rcParams['axes.linewidth'] = 0.5
+
+    a, pp = plt.subplots( 1, 1, figsize=bf.figsize )
+    mat = bf.heat_matrix
+    cmap = afni_cbar_to_mpl_cmap(bf.heat_cmap)
+
+    imopts = {'cmap': cmap}
+    if bf.zerocenter:
+        vmax = max([max([abs(x) for x in row]) for row in mat])
+        imopts['vmin'] = -vmax
+        imopts['vmax'] =  vmax
+
+    im = pp.imshow(mat, **imopts)
+    if bf.title:
+        pp.set_title(bf.title, fontsize=bf.fontsize)
+
+    xlabel = ''
+    ylabel = ''
+    if bf.all_subs:
+        xlabel = bf.all_subs[0].xlabel
+        ylabel = bf.all_subs[0].ylabel
+    pp.set_xlabel(xlabel if xlabel else 'subject', fontsize=bf.fontsize)
+    pp.set_ylabel(ylabel if ylabel else 'subject', fontsize=bf.fontsize)
+    a.colorbar(im, ax=pp, fraction=0.046, pad=0.04)
+
+    pp.tick_params( axis='both', which='major', direction='in',
+                    color='0.5', bottom=True, left=True, right=True )
+
+    save_1dplot_pyplot(bf)
+    print("++ Plotting heatmap")
+    return 0
+
+# ---------------------------------------------------------------------------
+
+def afni_cbar_to_mpl_cmap(cbar):
+    if cbar == 'Reds_and_Blues_Inv':
+        return 'RdBu_r'
+    elif cbar == 'Reds_and_Blues':
+        return 'RdBu'
+    return cbar
+
+# ---------------------------------------------------------------------------
+
+def save_1dplot_pyplot(bf):
+    if not(bf.margin_on):
+        plt.savefig( bf.fname, dpi=bf.dpi, facecolor=bf.bkgd_color)
+    else:
+        plt.savefig( bf.fname, dpi=bf.dpi, facecolor=bf.bkgd_color,
+                     bbox_inches='tight')
+    print("++ Done! Figure created:\n\t {}".format(bf.fname))
+
+# ---------------------------------------------------------------------------
+
 def calc_lw_from_npts(N):
     if N < 450:
         return 1.5
@@ -535,6 +704,7 @@ def populate_1dplot_fig(iopts):
     bigfig.set_fontsize( iopts.fontsize )
     bigfig.set_fontfamily( iopts.fontfamily )
     bigfig.set_fontstyles( iopts.fontstyles )
+    bigfig.set_bkgd_color( iopts.bkgd_color )
     bigfig.set_censor_arr( iopts.censor_arr )
     bigfig.set_censor_width( iopts.censor_width )
     bigfig.set_censor_RGB( iopts.censor_RGB )
@@ -546,6 +716,25 @@ def populate_1dplot_fig(iopts):
     bigfig.set_bplot_view( iopts.bplot_view )
     bigfig.set_legend_on( iopts.legend_on )
     bigfig.set_ylabels_maxlen( iopts.ylabels_maxlen )
+    bigfig.set_plot_kind( iopts.plot_kind )
+    bigfig.set_hist_opts( iopts.histbin, iopts.histwidth, iopts.hist_density )
+    bigfig.set_vlines( iopts.vlines )
+    bigfig.set_heat_opts( iopts.heat_matrix, iopts.heat_cmap,
+                          iopts.zerocenter )
+    bigfig.set_scatter( iopts.scatter_on )
+    bigfig.set_diagonal( iopts.diagonal )
+
+    if iopts.plot_kind == 'heat':
+        ss = laio.subplobj()
+        ss.set_xlabel( iopts.xlabel )
+        if iopts.ylabels:
+            ss.set_ylabel( iopts.ylabels[0] )
+        else:
+            ss.set_ylabel( "" )
+        bigfig.add_sub(ss)
+        bigfig.set_figsize( iopts.figsize )
+        bigfig.set_ngraph( False )
+        return bigfig
 
     for i in range(iopts.ndsets):
 
@@ -623,6 +812,15 @@ def make_censored_sublist( y, cen_arr ):
 # ---------------------------------------------------------------------------
 
 def populate_1dplot_arrays(iopts):
+
+    if iopts.plot_kind == 'heat':
+        iopts.read_heat_matrix()
+        iopts.read_reorder_file()
+        iopts.apply_heat_reorder()
+        iopts.npts = len(iopts.heat_matrix)
+        iopts.ndsets = 1
+        iopts.check_color_table()
+        return 0
 
     iopts.create_all_y()
     ok = iopts.check_dims_all_y() # check with number ylabels


### PR DESCRIPTION
Add histogram, heatmap, and scatter helpers to the Python `1dplot.py` backend.

- Add real binned histograms via `-histogram`
  - `-histbin N`
  - `-histwidth W`
  - `-density`
  - `-vline X [X ...]`

- Add matrix heatmaps via `-heat`
  - validates square 1D matrix input
  - supports `-reorder order.1D` to permute rows and columns together
  - supports `-zerocenter`
  - supports `-cbar`, including `Reds_and_Blues` and `Reds_and_Blues_Inv`

- Add scatter plot helpers
  - `-scatter` draws points instead of lines
  - `-diagonal` adds a dashed y=x reference line with equal scaling

- Update `1dplot.py -help` text for the new options