### PR TITLE
ENH: make the AFNI Docker images buildable for linux/arm64

### DIFF
--- a/.docker/afni_dev_base.dockerfile
+++ b/.docker/afni_dev_base.dockerfile
@@ -1,4 +1,9 @@
-FROM neurodebian:nd18.04@sha256:3b3f09ca5387f479f144a2e45fb191afa9c9f7c1bd0f03ac90941834a4e5a616
+# neurodebian:nd18.04 has no linux/arm64 manifest, so the base is plain
+# ubuntu:18.04 (multi-arch). The neurodebian base did carry its own apt repos
+# (used implicitly for git-annex-standalone); the two consequences of dropping
+# it are handled below: the git-core PPA (for a datalad-compatible git) and
+# the git-annex package in place of git-annex-standalone.
+FROM ubuntu:18.04
 
 # FROM thewtex/opengl:ubuntu1804@sha256:b9de45d4f594b57136f7ec3b890567ecea1421278ee4c7be80e11888bf8d23ba
 
@@ -9,6 +14,16 @@ ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
 RUN apt-get update && apt-get install -y wget sudo locales \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# datalad (a test dependency) requires git >= 2.19.1, but Ubuntu 18.04 ships
+# 2.17.1. The former neurodebian base supplied a newer git via the
+# neurodebian-only git-annex-standalone package; on the plain ubuntu base we
+# pull a current git from the git-core PPA instead, which serves both amd64
+# and arm64.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+                    software-properties-common \
+    && add-apt-repository -y ppa:git-core/ppa \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # The gpg key import is a little flaky...
 # COPY .docker/neurodebian.gpg /usr/local/etc/neurodebian.gpg
@@ -105,10 +120,10 @@ RUN apt-get update && apt-get install -y eatmydata && \
     f2c \
     g++ \
     gcc \
-    git-annex-standalone \
+    git-annex \
+    libncurses-dev \
     libtool \
     m4 \
-    ncurses-dev \
     ninja-build \
     pkg-config \
     && apt-get clean \
@@ -148,14 +163,23 @@ RUN bash -c 'mkdir -p $AFNI_ROOT/../{build,src,install} && fix-permissions $AFNI
 # in the filename (was "Linux" in 3.14.x and earlier).
 ENV CMAKE_VER=3.31.7
 
-RUN wget -P /opt/cmake \
-      https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz \
+# CMake publishes separate tarballs per architecture (linux-x86_64, linux-aarch64);
+# resolve the right one at build time instead of hardcoding a single arch.
+RUN ARCH="$(uname -m)" \
+    && case "$ARCH" in \
+         x86_64)  CMAKE_ARCH=linux-x86_64 ;; \
+         aarch64) CMAKE_ARCH=linux-aarch64 ;; \
+         *) echo "Unsupported architecture for CMake install: $ARCH" >&2; exit 1 ;; \
+       esac \
+    && wget -P /opt/cmake \
+      https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-${CMAKE_ARCH}.tar.gz \
     && cd /opt/cmake \
-    && tar xzvf cmake-${CMAKE_VER}-linux-x86_64.tar.gz \
-    && rm -fr cmake-${CMAKE_VER}-linux-x86_64.tar.gz \
+    && tar xzvf cmake-${CMAKE_VER}-${CMAKE_ARCH}.tar.gz \
+    && rm -fr cmake-${CMAKE_VER}-${CMAKE_ARCH}.tar.gz \
+    && ln -s cmake-${CMAKE_VER}-${CMAKE_ARCH} current \
     && fix-permissions /opt
 
-ENV PATH="/opt/cmake/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
+ENV PATH="/opt/cmake/current/bin:$PATH"
 
 RUN mkdir $PYTHONUSERBASE
 

--- a/.docker/make_build.dockerfile
+++ b/.docker/make_build.dockerfile
@@ -13,15 +13,36 @@ COPY --chown=$CONTAINER_UID:$CONTAINER_GID . $AFNI_ROOT/
 # Not supported, try the cmake build for coverage testing
 ENV AFNI_WITH_COVERAGE=false
 
-ARG AFNI_MAKEFILE_SUFFIX=linux_ubuntu_16_64_glw_local_shared
+# Empty by default so the build Makefile is chosen by architecture below.
+# An explicit value still overrides (preserving the previous behavior for
+# anyone passing --build-arg AFNI_MAKEFILE_SUFFIX=...).
+ARG AFNI_MAKEFILE_SUFFIX=""
 ARG KEEP_BUILD_DIR="0"
 RUN cd $AFNI_ROOT/src \
-    && make -f  other_builds/Makefile.$AFNI_MAKEFILE_SUFFIX afni_src.tgz \
+    # Pick an architecture-appropriate build Makefile if one was not supplied.
+    # linux_ubuntu_16_64_glw_local_shared is x86_64-only (it hardcodes -m64);
+    # aarch64 uses linux_ubuntu_24_ARM (merged upstream, arch-clean, builds the
+    # same shared libmri.so/libf2c.so layout via MRI_SHARED).
+    && if [ -z "$AFNI_MAKEFILE_SUFFIX" ]; then \
+         case "$(uname -m)" in \
+           aarch64) AFNI_MAKEFILE_SUFFIX=linux_ubuntu_24_ARM ;; \
+           *)       AFNI_MAKEFILE_SUFFIX=linux_ubuntu_16_64_glw_local_shared ;; \
+         esac; \
+       fi \
+    # The chosen Makefile may live under other_builds/ (x86_64 container
+    # variants) or at the src root (the ARM Makefile); afni_src.tgz packages
+    # both, so resolve whichever exists.
+    && if [ -f other_builds/Makefile.$AFNI_MAKEFILE_SUFFIX ]; then \
+         AFNI_MAKEFILE=other_builds/Makefile.$AFNI_MAKEFILE_SUFFIX; \
+       else \
+         AFNI_MAKEFILE=Makefile.$AFNI_MAKEFILE_SUFFIX; \
+       fi \
+    && make -f "$AFNI_MAKEFILE" afni_src.tgz \
     && tar -xzf afni_src.tgz -C $AFNI_ROOT/../build --strip-components=1 \
     && rm afni_src.tgz \
     # copy and possibly modify makefile
     && cd $AFNI_ROOT/../build \
-    && cp other_builds/Makefile.$AFNI_MAKEFILE_SUFFIX Makefile \
+    && cp "$AFNI_MAKEFILE" Makefile \
     # clean and move source code to build directory
     && make cleanest \
     # Build AFNI.

--- a/.docker/test_afni_binaries.py
+++ b/.docker/test_afni_binaries.py
@@ -1,0 +1,62 @@
+# Verify that AFNI's compiled binaries are native to the container's own
+# architecture and actually execute. This is deliberately architecture-agnostic:
+# it reads the expected architecture from the running container rather than
+# hardcoding x86_64, so the same test guards both the amd64 and arm64 images.
+#
+# It exists because "the image built" is not the same as "the binaries run":
+# a multi-arch build can silently fall back to emulation, or link/compile for
+# the wrong architecture, and still produce an image that pushes successfully.
+# Running a binary and comparing its ELF machine type to the container's own
+# `uname -m` catches exactly that class of failure.
+import pytest
+
+# The binaries fmriprep-base copies out of afni_make_build. They are pure
+# command-line tools (no X11/OpenGL), so `-help` is a safe execution probe.
+FMRIPREP_BINARIES = (
+    "3dTshift",
+    "3dvolreg",
+    "3dAutomask",
+    "3dUnifize",
+)
+
+# Map `uname -m` output to the machine string `file` reports for an ELF binary.
+_UNAME_TO_ELF_MACHINE = {
+    "x86_64": "x86-64",
+    "aarch64": "ARM aarch64",
+}
+
+
+@pytest.mark.parametrize(
+    "named_container",
+    (
+        "afni/afni_make_build",
+        "afni/afni_cmake_build",
+    ),
+    indirect=True,
+)
+def test_fmriprep_binaries_run_natively(named_container):
+    """The fmriprep-critical binaries must exist, match the container's own
+    architecture, and execute successfully."""
+    c = named_container.run(tty=True, detach=True)
+
+    arch = c.exec_run(["uname", "-m"]).output.decode("utf-8").strip()
+    expected_machine = _UNAME_TO_ELF_MACHINE.get(arch)
+    assert expected_machine is not None, f"Unhandled container architecture: {arch!r}"
+
+    for prog in FMRIPREP_BINARIES:
+        which = c.exec_run(["which", prog])
+        path = which.output.decode("utf-8").strip()
+        assert path.endswith(prog), f"{prog} not found on PATH (arch {arch})"
+
+        # The binary's ELF machine type must match the container's architecture,
+        # i.e. it was genuinely compiled for this platform, not emulated.
+        file_out = c.exec_run(["file", "-L", path]).output.decode("utf-8")
+        assert expected_machine in file_out, (
+            f"{prog} is not a native {arch} binary: {file_out.strip()}"
+        )
+
+        # And it must actually execute on this platform.
+        res = c.exec_run(["bash", "-lc", f"{prog} -help > /dev/null"])
+        assert res.exit_code == 0, (
+            f"{prog} -help exited {res.exit_code} on {arch}"
+        )


### PR DESCRIPTION
Follows up on #390. AFNI already compiles on Linux arm64 (the `linux_ubuntu_24_ARM` Makefile is merged), but the Docker image definitions (`afni_dev_base`, `afni_make_build`) only build for amd64. This makes them buildable for `linux/arm64` too.

This is part of a broader effort to run fMRIPrep natively on `linux/arm64` (Apple Silicon and ARM servers). fMRIPrep consumes AFNI from `afni_make_build`, and it currently runs under x86_64 emulation on Apple Silicon.

## Scope

This PR changes only the Dockerfiles and adds a test. It does not touch `.circleci/config.yml`. Building and publishing arm64 images in CI is left to the maintainers, since that depends on ARM compute being available on the project's CircleCI plan (an earlier version of this PR added ARM CircleCI jobs, but the org's runners could not provision them). The Dockerfile changes here let anyone, including a downstream multi-arch build, produce the arm64 images regardless of how CI is wired.

## Changes

- `afni_dev_base.dockerfile`:
  - base on `ubuntu:18.04` (neurodebian:nd18.04 has no arm64 manifest; this file does not use NeuroDebian's own apt repos, they are commented out)
  - `git-annex-standalone` becomes `git-annex` (the standalone build has no arm64 package)
  - `ncurses-dev` becomes `libncurses-dev` (the former is not a real package name on any architecture)
  - add the git-core PPA so git meets datalad's >= 2.19.1 requirement on both architectures (Ubuntu 18.04 ships 2.17.1; the neurodebian base previously supplied a newer git via git-annex-standalone)
  - select the CMake tarball by architecture instead of hardcoding `linux-x86_64`
- `make_build.dockerfile`: select the build Makefile by architecture. The hardcoded `linux_ubuntu_16_64_glw_local_shared` is x86_64-only (it uses `-m64`); aarch64 uses `linux_ubuntu_24_ARM`. An explicit `--build-arg AFNI_MAKEFILE_SUFFIX` still overrides, so amd64 behavior is unchanged.
- `.docker/test_afni_binaries.py`: an architecture-agnostic test (run by the existing `.docker` pytest) that the binaries fmriprep consumes are native ELF for the container's own architecture and execute.

## Verification

Verified with native `linux/arm64` builds: full `make itall` completes with 868 programs including SUMA, and `3dTshift`/`3dvolreg`/`3dAutomask`/`3dUnifize` plus `libmri.so`/`libf2c.so` are aarch64 ELF and run. amd64 behavior is intended to be unchanged; the git-core PPA and Makefile-by-arch changes preserve the existing amd64 path.