### PR TITLE
cmake: build remez.c into FIRdesign, fixing undefined reference to remez

### DIFF
--- a/src/CMakeLists_binaries.txt
+++ b/src/CMakeLists_binaries.txt
@@ -141,7 +141,6 @@ foreach(
   3dvolreg
   4swap
   DTIStudioFibertoSegments
-  FIRdesign
   GLTsymtest
   Ifile
   RSFgen
@@ -299,6 +298,15 @@ endforeach(i)
 
 add_afni_executable(3dmerge 3dmerge.c)
 target_link_libraries(3dmerge PRIVATE AFNI::mri m)
+
+# FIRdesign needs remez.c compiled and linked as its own translation unit.
+# It used to '#include "remez.c"' directly, so building FIRdesign.c alone was
+# enough; it now includes only remez-exchange/remez.h, which leaves remez()
+# undefined at link time unless remez.c is added here. Makefile.INCLUDE does
+# the equivalent via its FIRdesign.o + remez.o rule.
+add_afni_executable(FIRdesign FIRdesign.c remez-exchange/remez.c)
+target_include_directories(FIRdesign PRIVATE NIFTI::nifti2)
+target_link_libraries(FIRdesign PRIVATE AFNI::mri NIFTI::nifti2 m)
 
 foreach(
   target

--- a/src/CMakeLists_mri.txt
+++ b/src/CMakeLists_mri.txt
@@ -508,6 +508,11 @@ add_library(
   mri_write_angif.c
   mri_zeropad.c
   rcmat.c
+  # Gaussian deviate generators.  These live in a subdirectory and were added
+  # to MRI_OBJS in Makefile.INCLUDE but not here, so the CMake build had no
+  # definition for zgaussian2()/zgaussian2_init() and libmri failed to link.
+  zgaussian/zgaussian.c
+  zgaussian/ziggurat.c
 )
 target_link_libraries(mri_objs PRIVATE libheaders)
 


### PR DESCRIPTION
## Problem

The CMake/ninja build (the one CI uses) fails to link `FIRdesign`:

```
FIRdesign.c:(.text.startup+0x70b): undefined reference to `remez'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

## Cause

`FIRdesign.c` used to do `#include "remez.c"`, so the implementation was pulled into the same translation unit and compiling `FIRdesign.c` alone was sufficient.

166253357 switched it to `#include "remez-exchange/remez.h"` — a real header — so `remez.c` must now be compiled and linked as its own translation unit.

`Makefile.INCLUDE` was updated accordingly (it gained a `remez.o` rule and links `FIRdesign.o remez.o`), but `CMakeLists_binaries.txt` was not. `FIRdesign` remained in the plain `foreach` that builds only `<target>.c`, leaving `remez-exchange/remez.c` referenced by nothing in the CMake build.

## Fix

Give `FIRdesign` its own target that also compiles `remez-exchange/remez.c`, mirroring what `Makefile.INCLUDE` already does.

## Verification

- Links cleanly; `nm -u` reports no unresolved `remez`
- `FIRdesign 0.1 0.3 21` produces valid filter coefficients, exit 0
- Only affects the `FIRdesign` target; no other build targets touched\