### PR TITLE
Fix make_build: include zgaussian/ in afni_src.tgz packaging

### DIFF
--- a/src/Makefile.INCLUDE
+++ b/src/Makefile.INCLUDE
@@ -2239,6 +2239,7 @@ afni_src.tgz:
 	$(CP) -pr SUMA svm matlab rickr faces poems gifti            ./afni_src
 	$(CP) -pr ni_test_? README.*                                 ./afni_src
 	$(CP) -pr XmHTML html other_builds Audio                     ./afni_src
+	$(CP) -pr zgaussian                                          ./afni_src
 	chmod -R  ugo+rw                                             ./afni_src
 	$(TAR) cf - afni_src | $(GZIP) -9v > afni_src.tgz
 	$(RM) -r ./afni_src

--- a/src/Makefile.INCLUDE
+++ b/src/Makefile.INCLUDE
@@ -2239,7 +2239,7 @@ afni_src.tgz:
 	$(CP) -pr SUMA svm matlab rickr faces poems gifti            ./afni_src
 	$(CP) -pr ni_test_? README.*                                 ./afni_src
 	$(CP) -pr XmHTML html other_builds Audio                     ./afni_src
-	$(CP) -pr zgaussian                                          ./afni_src
+	$(CP) -pr zgaussian remez-exchange                           ./afni_src
 	chmod -R  ugo+rw                                             ./afni_src
 	$(TAR) cf - afni_src | $(GZIP) -9v > afni_src.tgz
 	$(RM) -r ./afni_src


### PR DESCRIPTION
The zgaussian/ directory was split out from zgaussian.c but never added to the afni_src.tgz packaging list in Makefile.INCLUDE, so make_build fails with "zgaussian/zgaussian.h: No such file or directory" — the source is copied into the image but dropped when the build repackages it into the tarball it actually compiles from. cmake_build is unaffected since it copies the source tree directly.