### PR TITLE
CMakeLists_x_dependent.txt: fix spelling mistake in target

### DIFF
--- a/src/CMakeLists_x_dependent.txt
+++ b/src/CMakeLists_x_dependent.txt
@@ -33,7 +33,7 @@ target_link_libraries(
            X11::X11
            X11::Xext
   PRIVATE
-          $<IF:$<BOOL:${USE_SYSTEM_XMHTML}>,XmTHML::XmHTML,AFNI::XmHTML>
+          $<IF:$<BOOL:${USE_SYSTEM_XMHTML}>,XmHTML::XmHTML,AFNI::XmHTML>
 )
 
 set_source_files_properties(


### PR DESCRIPTION
@pmolfese @leej3 @afni-rickr : am I correct that this PR fixes a typo in the CMake targets? or was the initial spelling purposeful to overcome a typo somewhere?