### PR TITLE
3dttest++/3dGroupInCorr: fix paired-zskip zeroing, BminusA negation slots, and t-to-z roundoff saturation

### DIFF
--- a/src/3dGroupInCorr.c
+++ b/src/3dGroupInCorr.c
@@ -4198,10 +4198,13 @@ double GIC_student_t2z( double tt , double dof )
    xx = dof/(dof + tt*tt) ;
    pp = GIC_incbeta( xx , 0.5*dof , 0.5 , bb ) ;
 
-   if( tt > 0.0 ) pp = 1.0 - 0.5 * pp ;
-   else           pp = 0.5 * pp ;
+   /* compute z directly from the (small) 2-sided tail probability pp;
+      the old form 1.0-0.5*pp rounds to 1.0 for pp < 2e-16, which
+      saturated the result at ZMAX and lost precision above z ~ 7.7
+      (same roundoff fix as student_t2z in mri_stats.c) */
 
-   xx = - GIC_qginv(pp) ;
+   if( tt > 0.0 ) xx =  GIC_qginv(0.5*pp) ;
+   else           xx = -GIC_qginv(0.5*pp) ;
    if( xx > ZMAX ) xx = ZMAX ; else if( xx < -ZMAX ) xx = -ZMAX ;
    return xx ;
 }

--- a/src/3dttest++.c
+++ b/src/3dttest++.c
@@ -4845,7 +4845,7 @@ LABELS_ARE_DONE:  /* target for goto above */
              }
            }
 
-           if( !singletonA ){  /* -zskip for setA separately from setB */
+           if( !IS_PAIRED && !singletonA ){  /* -zskip for setA separately from setB */
              for( ii=nz=0 ; ii < nval_AAA ; ii++ ) nz += (datAAA[ii] == 0.0f) ;
              if( nz > 0 ){            /* copy nonzero vals to a new array */
                nAAA = nval_AAA - nz ;
@@ -4973,7 +4973,12 @@ LABELS_ARE_DONE:  /* target for goto above */
        } /* end of covariates analysis */
 
        if( BminusA && ntwosam ){  /* negate 2 sample results? [05 Nov 2010] */
-         for( ii=0 ; ii < ntwosam ; ii++ ) resar[ii] = -resar[ii] ;
+         /* resar[] always stores the 2-sample results as interleaved
+            (mean,statistic) pairs -- 2*(mcov+1) slots -- regardless of
+            -nomeans/-notests; ntwosam counts output VOLUMES, so using it
+            here negated the wrong slots when -nomeans or -notests was
+            given (the output statistic kept the A-B sign) */
+         for( ii=0 ; ii < 2*(mcov+1) ; ii++ ) resar[ii] = -resar[ii] ;
        }
 
        /* save min and max values from resar [16 Mar 2017] */
@@ -6620,10 +6625,13 @@ double GIC_student_t2z( double tt , double dof )
    xx = dof/(dof + tt*tt) ;
    pp = GIC_incbeta( xx , 0.5*dof , 0.5 , bb ) ;
 
-   if( tt > 0.0 ) pp = 1.0 - 0.5 * pp ;
-   else           pp = 0.5 * pp ;
+   /* compute z directly from the (small) 2-sided tail probability pp;
+      the old form 1.0-0.5*pp rounds to 1.0 for pp < 2e-16, which
+      saturated the result at ZMAX and lost precision above z ~ 7.7
+      (same roundoff fix as student_t2z in mri_stats.c) */
 
-   xx = - GIC_qginv(pp) ;
+   if( tt > 0.0 ) xx =  GIC_qginv(0.5*pp) ;
+   else           xx = -GIC_qginv(0.5*pp) ;
    if( xx > ZMAX ) xx = ZMAX ; else if( xx < -ZMAX ) xx = -ZMAX ;
    return xx ;
 }


### PR DESCRIPTION
Fixes #952.

Three group-statistics correctness fixes:

1. **`-paired -zskip`**: add the missing `!IS_PAIRED` guard on the setA-only zskip reduction (mirroring the setB block). Previously, after the paired branch built pair-aligned reduced arrays, the A-only block overwrote them; when both sets contained zeros at non-identical subject indices the paired t-test detected a length mismatch and the voxel was silently written as mean=0, t/z=0. Verified with a standalone harness replicating the exact code path (correct paired t=5.0 → program output 0 before the fix).

2. **`-BminusA` + `-nomeans`/`-notests`**: negate the full `2*(mcov+1)`-slot two-sample region of `resar[]` (which always stores interleaved mean/statistic pairs) instead of `ntwosam` slots (which counts output volumes). With `-nomeans` the statistic previously kept the A−B sign while labeled B−A. The default output mode is unchanged: there `ntwosam == 2*(mcov+1)` already.

3. **`GIC_student_t2z`** (both files): compute z directly from the small 2-sided tail probability, `qginv(0.5*pp)`, instead of `1.0 - 0.5*pp` which rounds to 1.0 for p < ~2e-16 — the same roundoff fix `mri_stats.c`'s `student_t2z` has carried for years. Verified against scipy on the extracted functions: t=20/30/50 at df=20 now give 7.729466 / 8.673368 / 9.755154 (old: 7.728523 / 13.0 / 13.0); values below z≈7.7 are unchanged to 6 decimals. Affects `-toz` outputs (including `-Clustsim` z-inputs at extreme voxels) and 3dGroupInCorr.

Both files compile cleanly with `-Wall`.