### PR TITLE
3dBrickStat: fix -automask voxel-scan truncation and -absolute integer truncation

### DIFF
--- a/src/3dBrickStat.c
+++ b/src/3dBrickStat.c
@@ -495,9 +495,12 @@ int main( int argc , char * argv[] )
 
    if(automask && mmm == NULL ){
       mmm = THD_automask( old_dset ) ;
-      for(i=0;i<nxyz;i++) {
-         if(mmm[i]!=0) ++mmvox;
-      }
+      /* mmvox is used below as the voxel-scan bound in Max_func, where
+         the -mask case sets it to the full grid size; setting it to the
+         in-mask COUNT made the scan silently stop mmvox voxels into the
+         volume, dropping roughly the upper part of the brain in storage
+         order from -mean/-sum/-var/-stdev/-min/-max etc. */
+      mmvox = nxyz ;
    }
 
    if(quick_flag)
@@ -795,7 +798,8 @@ static void Max_func(int Minflag, int Maxflag, int Meanflag, int Countflag,
                }
             }
             /* use only absolute values */
-            if(Absflag) voxval = abs(voxval);
+            if(Absflag) voxval = fabs(voxval); /* abs() truncated the
+                                    double to int, flooring magnitudes */
             /* limit data by sign */
             if(((voxval<0)&&Negflag)||((voxval==0)&&Zeroflag)
                ||((voxval>0)&&Posflag)) {


### PR DESCRIPTION
Fixes #955 .

1. **`-automask`**: set `mmvox` to the full grid size (matching what the `-mask` path guarantees), since `Max_func` uses it as the voxel-scan bound. Previously it held the in-mask count, so the slow-mode statistics scanned only the first `mmvox` voxels of the volume and silently dropped the rest of the mask.

2. **`-absolute`**: `voxval = fabs(voxval)` instead of `abs(voxval)` — the integer `abs()` truncated the double toward zero (and overflows for |values| > 2³¹).

Compiles cleanly with `-Wall`.