### PR TITLE
3dTshift: -no_detrend demeaned the wrong array for the second voxel of each pair

### DIFF
--- a/src/3dTshift.c
+++ b/src/3dTshift.c
@@ -630,7 +630,10 @@ int main( int argc , char *argv[] )
             if( TS_detrend )
                THD_linear_detrend( ntt-ignore , gar+ignore , &g0,&g1 ) ;
             else
-               THD_const_detrend( ntt-ignore , far+ignore , &g0 ) ;
+               THD_const_detrend( ntt-ignore , gar+ignore , &g0 ) ; /* was
+                    far+ignore: with -no_detrend the mean was removed from
+                    far a second time (a near no-op) while gar was shifted
+                    with its full DC offset against the zero-filled edges */
 
             for( gmin=gmax=gar[ignore],jj=ignore+1 ; jj < ntt ; jj++ ){
                     if( gar[jj] < gmin ) gmin = gar[jj] ;


### PR DESCRIPTION
Fixes #957 .

One-word fix: pass `gar+ignore` (not `far+ignore`) to `THD_const_detrend` in the second voxel's branch, mirroring the first voxel's block. Previously, with `-no_detrend`, the second voxel of each pair was shifted with its full DC offset against zero-filled (or Fourier-wrapped) edges and only a ≈0 mean was restored afterward, producing even/odd-voxel striping near run edges. `-no_detrend` forces `TS_rlt=2`, so the restore path re-adds exactly `g0` and the linear-trend variables are never read in this mode. Compiles cleanly with `-Wall`.