### PR TITLE
3dmaskave/mri_percents: fix one-past-end reads at extreme percentiles

### DIFF
--- a/src/3dmaskave.c
+++ b/src/3dmaskave.c
@@ -676,7 +676,9 @@ int main( int argc , char * argv[] )
               float *qar=(float *)malloc(sizeof(float)*mc) ; int iq ;
               memcpy(qar,exar,sizeof(float)*mc) ;
               qsort_float(mc,qar) ;
-              iq = (int)rintf(0.01f*perc*mc) ; sum = qar[iq] ; free(qar) ;
+              iq = (int)rintf(0.01f*perc*mc) ;
+              if( iq >= mc ) iq = mc-1 ;   /* -perc near 100 rounded to mc: OOB read */
+              sum = qar[iq] ; free(qar) ;
             }
 
             sum = mfac * sum ;
@@ -738,7 +740,9 @@ int main( int argc , char * argv[] )
               float *qar=(float *)malloc(sizeof(float)*mc) ; int iq ;
               memcpy(qar,exar,sizeof(float)*mc) ;
               qsort_float(mc,qar) ;
-              iq = (int)rintf(0.01f*perc*mc) ; sum = qar[iq] ; free(qar) ;
+              iq = (int)rintf(0.01f*perc*mc) ;
+              if( iq >= mc ) iq = mc-1 ;   /* -perc near 100 rounded to mc: OOB read */
+              sum = qar[iq] ; free(qar) ;
             }
             sum = mfac * sum ;
 
@@ -799,7 +803,9 @@ int main( int argc , char * argv[] )
               float *qar=(float *)malloc(sizeof(float)*mc) ; int iq ;
               memcpy(qar,exar,sizeof(float)*mc) ;
               qsort_float(mc,qar) ;
-              iq = (int)rintf(0.01f*perc*mc) ; sum = qar[iq] ; free(qar) ;
+              iq = (int)rintf(0.01f*perc*mc) ;
+              if( iq >= mc ) iq = mc-1 ;   /* -perc near 100 rounded to mc: OOB read */
+              sum = qar[iq] ; free(qar) ;
             }
             sum = mfac * sum ;
 

--- a/src/mri_percents.c
+++ b/src/mri_percents.c
@@ -737,8 +737,10 @@ void mri_percents( MRI_IMAGE *im , int nper , float per[] )
 
          per[0] = far[0] ;
          for( pp=1 ; pp < nper ; pp++ ){
-            fi = frac *pp ; ii = fi ; fi = fi - ii ;
-            per[pp] = (1.0-fi) * far[ii] + fi * far[ii+1] ;
+            fi = frac *pp ; ii = fi ;
+            if( ii >= nvox-1 ) per[pp] = far[nvox-1] ;  /* no upper neighbor */
+            else { fi = fi - ii ;
+                   per[pp] = (1.0-fi) * far[ii] + fi * far[ii+1] ; }
          }
          per[nper] = far[nvox-1] ;
          mri_free( inim ) ;
@@ -759,8 +761,10 @@ void mri_percents( MRI_IMAGE *im , int nper , float per[] )
 
          per[0] = sar[0] ;
          for( pp=1 ; pp < nper ; pp++ ){
-            fi = frac *pp ; ii = fi ; fi = fi - ii ;
-            per[pp] = (1.0-fi) * sar[ii] + fi * sar[ii+1] ;
+            fi = frac *pp ; ii = fi ;
+            if( ii >= nvox-1 ) per[pp] = sar[nvox-1] ;  /* no upper neighbor */
+            else { fi = fi - ii ;
+                   per[pp] = (1.0-fi) * sar[ii] + fi * sar[ii+1] ; }
          }
          per[nper] = sar[nvox-1] ;
          mri_free( inim ) ;
@@ -966,9 +970,10 @@ ENTRY("mri_quantile") ;
          qsort_float( nvox , far ) ;
 
          fi   = alpha * nvox ;
-         ii   = (int) fi ; if( ii >= nvox ) ii = nvox-1 ;
-         fi   = fi - ii ;
-         quan = (1.0-fi) * far[ii] + fi * far[ii+1] ;
+         ii   = (int) fi ;
+         if( ii >= nvox-1 ){ quan = far[nvox-1] ; }  /* no upper neighbor */
+         else { fi   = fi - ii ;
+                quan = (1.0-fi) * far[ii] + fi * far[ii+1] ; }
          mri_free( inim ) ;
       }
       break ;
@@ -986,9 +991,10 @@ ENTRY("mri_quantile") ;
          qsort_short( nvox , sar ) ;
 
          fi   = alpha * nvox ;
-         ii   = (int) fi ; if( ii >= nvox ) ii = nvox-1 ;
-         fi   = fi - ii ;
-         quan = (1.0-fi) * sar[ii] + fi * sar[ii+1] ;
+         ii   = (int) fi ;
+         if( ii >= nvox-1 ){ quan = sar[nvox-1] ; }  /* no upper neighbor */
+         else { fi   = fi - ii ;
+                quan = (1.0-fi) * sar[ii] + fi * sar[ii+1] ; }
          mri_free( inim ) ;
       }
       break ;
@@ -1044,15 +1050,17 @@ ENTRY("mri_twoquantiles") ;
 
          if( alpha > 0.0f && alpha < 1.0f ){
            fi    = alpha * nvox ;
-           ii    = (int) fi ; if( ii >= nvox ) ii = nvox-1 ;
-           fi    = fi - ii ;
-           qalph = (1.0-fi) * far[ii] + fi * far[ii+1] ;
+           ii    = (int) fi ;
+           if( ii >= nvox-1 ){ qalph = far[nvox-1] ; }  /* no upper neighbor */
+           else { fi    = fi - ii ;
+                  qalph = (1.0-fi) * far[ii] + fi * far[ii+1] ; }
          }
          if( beta > 0.0f && beta < 1.0f ){
            fi    = beta * nvox ;
-           ii    = (int) fi ; if( ii >= nvox ) ii = nvox-1 ;
-           fi    = fi - ii ;
-           qbeta = (1.0-fi) * far[ii] + fi * far[ii+1] ;
+           ii    = (int) fi ;
+           if( ii >= nvox-1 ){ qbeta = far[nvox-1] ; }  /* no upper neighbor */
+           else { fi    = fi - ii ;
+                  qbeta = (1.0-fi) * far[ii] + fi * far[ii+1] ; }
          }
          mri_free( inim ) ;
       }
@@ -1072,15 +1080,17 @@ ENTRY("mri_twoquantiles") ;
 
          if( alpha > 0.0f && alpha < 1.0f ){
            fi    = alpha * nvox ;
-           ii    = (int) fi ; if( ii >= nvox ) ii = nvox-1 ;
-           fi    = fi - ii ;
-           qalph = (1.0-fi) * sar[ii] + fi * sar[ii+1] ;
+           ii    = (int) fi ;
+           if( ii >= nvox-1 ){ qalph = sar[nvox-1] ; }  /* no upper neighbor */
+           else { fi    = fi - ii ;
+                  qalph = (1.0-fi) * sar[ii] + fi * sar[ii+1] ; }
          }
          if( beta > 0.0f && beta < 1.0f ){
            fi    = beta * nvox ;
-           ii    = (int) fi ; if( ii >= nvox ) ii = nvox-1 ;
-           fi    = fi - ii ;
-           qbeta = (1.0-fi) * sar[ii] + fi * sar[ii+1] ;
+           ii    = (int) fi ;
+           if( ii >= nvox-1 ){ qbeta = sar[nvox-1] ; }  /* no upper neighbor */
+           else { fi    = fi - ii ;
+                  qbeta = (1.0-fi) * sar[ii] + fi * sar[ii+1] ; }
          }
          mri_free( inim ) ;
       }


### PR DESCRIPTION
Fixes #963 .

1. **3dmaskave `-perc`**: clamp the rounded index to `mc-1` in all three datum branches.
2. **mri_percents.c**: at all 8 interpolation sites (float and short variants of `mri_percents`, `mri_quantile`, `mri_twoquantiles`), when the integer rank reaches the last element, return `ar[nvox-1]` directly instead of blending with a nonexistent upper neighbor. Interior percentiles are computed exactly as before.

Compiles cleanly with `-Wall`.