### PR TITLE
Assorted one-line correctness fixes (armacor, 3dXClustSim, edt_coerce, 3dpc, 3dDWItoDT)

### DIFF
--- a/src/3dDWItoDT.c
+++ b/src/3dDWItoDT.c
@@ -2624,8 +2624,13 @@ Computebmatrix (MRI_IMAGE * grad1Dptr, int NO_ZERO_ROW1)
 
             //if((Gx==0.0) && (Gy==0.0) && (Gz==0.0))
             gscale = sqrt(Gx*Gx + Gy*Gy + Gz*Gz);
-            if( gscale<BMAX_REF )
+            if( gscale<BMAX_REF ){
                B0list[i+1] = 1;   /* no gradient applied*/
+               gscale = 1.;       /* avoid 0/0 = NaN in the divisions below
+                                     for an exactly-zero gradient row (same
+                                     guard as Form_R_Matrix); the b-matrix
+                                     elements are ~0 for such rows anyway */
+            }
             else{
                B0list[i+1] = 0;
                if(gscale > MAX_BVAL)

--- a/src/3dXClustSim.c
+++ b/src/3dXClustSim.c
@@ -1683,7 +1683,7 @@ GARP_LOOPBACK:
      if( ntfp == ntfp_all ){
        ntfp_all += 128 ;
        tfs = (float *)realloc(tfs,sizeof(float)*ntfp_all) ;
-       fps = (float *)realloc(tfs,sizeof(float)*ntfp_all) ;
+       fps = (float *)realloc(fps,sizeof(float)*ntfp_all) ;
      }
      tfs[ntfp] = tfrac ; fps[ntfp] = farperc ; ntfp++ ;
 
@@ -2491,7 +2491,7 @@ FARP_LOOPBACK:
      if( ntfp == ntfp_all ){
        ntfp_all += 128 ;
        tfs = (float *)realloc(tfs,sizeof(float)*ntfp_all) ;
-       fps = (float *)realloc(tfs,sizeof(float)*ntfp_all) ;
+       fps = (float *)realloc(fps,sizeof(float)*ntfp_all) ;
      }
      tfs[ntfp] = tfrac ; fps[ntfp] = farperc ; ntfp++ ;
 

--- a/src/3dpc.c
+++ b/src/3dpc.c
@@ -686,7 +686,9 @@ int main( int argc , char *argv[] )
          EDIT_substitute_brick( new_dset , jj , MRI_short , bout ) ;
        }
 
-       sprintf(vname,"var=%6.3f%%" , 100.0*perc[jj]+0.499 ) ;
+       sprintf(vname,"var=%6.3f%%" , 100.0*perc[jj] ) ; /* +0.499 was an
+                        integer-rounding idiom left in a %f format, inflating
+                        every label by ~0.5 percentage points */
        EDIT_BRICK_LABEL( new_dset , jj , vname ) ;
      }
      free(fout) ;

--- a/src/armacor.c
+++ b/src/armacor.c
@@ -144,7 +144,9 @@ doublevec * arma31_correlations( double a , double r1 , double t1 ,
 
      /* check to see if we've shrunk as far as needed */
 
-     if( abs(cnew) < ccut ){
+     if( fabs(cnew) < ccut ){  /* abs() truncated the double to int, so this
+                                  was true for every |cnew| < 1 and the
+                                  sequence always stopped after 3 lags */
        nzz++ ;                /* how many undersized in a row? */
        if( nzz > 2 ) break ;  /* 3 strikes and you are OUT! */
      } else {
@@ -340,7 +342,9 @@ doublevec * arma51_correlations( double a , double r1 , double t1 ,
 
      /* check to see if we've shrunk as far as needed */
 
-     if( abs(cnew) < ccut ){
+     if( fabs(cnew) < ccut ){  /* abs() truncated the double to int, so this
+                                  was true for every |cnew| < 1 and the
+                                  sequence always stopped after 3 lags */
        nzz++ ;                /* how many undersized in a row? */
        if( nzz > 2 ) break ;  /* 3 strikes and you are OUT! */
      } else {

--- a/src/edt_coerce.c
+++ b/src/edt_coerce.c
@@ -52,7 +52,10 @@ ENTRY("EDIT_coerce_type") ;
         bin  = (byte  *)ivol ;
         frgb = (float *)malloc(sizeof(float)*nxyz) ;
         for( ii=0 ; ii < nxyz ; ii++ )
-          frgb[ii] = 255.0f*(0.299f*bin[3*ii]+0.587f*bin[3*ii+1]+0.144f*bin[3*ii+2]) ;
+          frgb[ii] = 0.299f*bin[3*ii]+0.587f*bin[3*ii+1]+0.114f*bin[3*ii+2] ;
+          /* was 255*(...) with blue weight 0.144: inputs are already 0-255,
+             so values came out up to ~65790 and hue-skewed; 0.299/0.587/0.114
+             matches the RGB->gray conversions elsewhere (thd_bstats.c etc.) */
       }
       break ;
    }


### PR DESCRIPTION
Fixes #965 .

Five independent one-or-two-line fixes, one commit, each explained in the commit message: `fabs()` for armacor's correlation cutoff (the int `abs()` truncated every |c|<1 to 0, always stopping the ARMA(3,1)/(5,1) correlation sequence at lag 5/7); `realloc(fps, …)` for ETAC's copy-pasted `realloc(tfs, …)` (aliasing/use-after-free when the calibration history exceeds 128 entries); Rec.601 luma 0.299/0.587/0.114 without the spurious ×255 in `EDIT_coerce_type`'s RGB→gray; drop the +0.499 from 3dpc's `%f` variance labels; and set gscale=1 for below-threshold gradient rows in `Computebmatrix` (mirroring `Form_R_Matrix`'s existing guard) so `0 0 0` rows no longer produce NaN tensor fits. All files compile cleanly with `-Wall`.