### PR TITLE
NIfTI read: keep the time axis consistent with the sub-bricks present; 3dvolreg: exit non-zero when a write fails (#73)

### DIFF
--- a/src/3dvolreg.c
+++ b/src/3dvolreg.c
@@ -1301,8 +1301,12 @@ int main( int argc , char *argv[] )
 
    /*-- save new dataset to disk --*/
 
+   /* exit non-zero if a write fails, rather than leaving an empty
+    * or missing output file behind     [issue #73]   3 Sep 2026 */
+
    if( !null_output ){
-     DSET_write(new_dset) ;
+     if( !DSET_write(new_dset) )
+       ERROR_exit("Failed to write output dataset %s",DSET_BRIKNAME(new_dset)) ;
      if( VL_verbose )
        INFO_message("Wrote dataset to disk in %s",DSET_BRIKNAME(new_dset));
    }
@@ -1311,17 +1315,20 @@ int main( int argc , char *argv[] )
 
    if( VL_xdset != NULL ){    /* 04 Apr 2012 */
      if( VL_savedisp19 ) VL_normalize_timeseries(VL_xdset) ;
-     DSET_write(VL_xdset) ;
+     if( !DSET_write(VL_xdset) )
+       ERROR_exit("Failed to write output dataset %s",DSET_BRIKNAME(VL_xdset)) ;
      if( VL_verbose ) INFO_message("Wrote dataset to disk in %s",DSET_BRIKNAME(VL_xdset));
    }
    if( VL_ydset != NULL ){
      if( VL_savedisp19 ) VL_normalize_timeseries(VL_ydset) ;
-     DSET_write(VL_ydset) ;
+     if( !DSET_write(VL_ydset) )
+       ERROR_exit("Failed to write output dataset %s",DSET_BRIKNAME(VL_ydset)) ;
      if( VL_verbose ) INFO_message("Wrote dataset to disk in %s",DSET_BRIKNAME(VL_ydset));
    }
    if( VL_zdset != NULL ){
      if( VL_savedisp19 ) VL_normalize_timeseries(VL_zdset) ;
-     DSET_write(VL_zdset) ;
+     if( !DSET_write(VL_zdset) )
+       ERROR_exit("Failed to write output dataset %s",DSET_BRIKNAME(VL_zdset)) ;
      if( VL_verbose ) INFO_message("Wrote dataset to disk in %s",DSET_BRIKNAME(VL_zdset));
    }
 

--- a/src/thd_initdblk.c
+++ b/src/thd_initdblk.c
@@ -1172,6 +1172,22 @@ ENTRY("THD_datablock_apply_atr") ;
        dset->taxis->dz_sl   = 0.0 ;
      }
 
+     /* The number of sub-bricks actually present (blk->nvals, from the
+      * NIFTI header) is authoritative.  If the AFNI extension's TAXIS_NUMS
+      * disagrees, the dataset was sliced by some other program that kept
+      * the old extension (nibabel does this).  Keep the time axis, but
+      * limit it to the sub-bricks that exist; otherwise DSET_NUM_TIMES
+      * and DSET_NVALS differ, and e.g. writing the dataset back out as
+      * NIFTI fails with "NBL does not match nim".
+      *                                     [issue #73]   3 Sep 2026 */
+     if( dset->taxis->ntt != blk->nvals ){
+       WARNING_message("AFNI extension of %s claims %d time points, but the"
+                       " dataset has %d sub-bricks; using %d",
+                       DSET_HEADNAME(dset), dset->taxis->ntt,
+                       blk->nvals, blk->nvals) ;
+       dset->taxis->ntt = blk->nvals ;
+     }
+
    }
 
    /* get template space for dataset */

--- a/tests/scripts/test_3dvolreg.py
+++ b/tests/scripts/test_3dvolreg.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+import subprocess as sp
+
+import nibabel as nb
+import numpy as np
+import pytest
+from afni_test_utils import tools
+
+# No external data: the input is synthesised in the test's output directory.
+data_paths = {}
+
+NX, NY, NZ, NT = 12, 12, 6, 8
+
+
+def make_epi_with_stale_afni_extension(outdir):
+    """Return a 4D NIfTI whose AFNI extension says NT volumes while its header
+    (and data) hold only NT-1.
+
+    This is what a file looks like after a nibabel/nilearn based step drops
+    volumes from an AFNI-written NIfTI but keeps the header extensions, as in
+    the MRIQC pipeline of issue #73."""
+    rng = np.random.default_rng(0)
+    arr = (1000 + 100 * rng.standard_normal((NX, NY, NZ, NT))).round()
+    img = nb.Nifti1Image(arr.astype(np.int16), np.diag([3.0, 3.0, 3.0, 1.0]))
+    img.header.set_xyzt_units("mm", "sec")
+    img.header["pixdim"][4] = 2.0
+    synth = outdir / "synth.nii"
+    nb.save(img, synth)
+
+    # Let AFNI write the file, so it carries an AFNI extension (TAXIS_NUMS etc.)
+    withext = outdir / "withext.nii"
+    sp.run(
+        ["3dcalc", "-a", str(synth), "-expr", "a", "-prefix", str(withext)],
+        check=True,
+        stdout=sp.DEVNULL,
+        stderr=sp.DEVNULL,
+    )
+
+    # Drop the last volume with nibabel; extensions are carried over unchanged.
+    src = nb.load(withext)
+    dropped = nb.Nifti1Image(
+        np.asarray(src.dataobj)[..., :-1], src.affine, header=src.header
+    )
+    assert len(dropped.header.extensions) > 0
+    out = outdir / "dropped.nii"
+    nb.save(dropped, out)
+    return out
+
+
+def test_3dvolreg_nifti_stale_afni_extension(data):
+    """3dvolreg must write a complete output (and not exit 0 with an empty
+    file) when the input's AFNI extension disagrees with the NIfTI header
+    about the number of volumes (issue #73)."""
+    infile = make_epi_with_stale_afni_extension(data.outdir)
+
+    # the length of the time axis must agree with the number of sub-bricks
+    ntimes, nv = sp.run(
+        ["3dinfo", "-ntimes", "-nv", str(infile)],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.split()[-2:]
+    assert int(ntimes) == int(nv) == NT - 1
+
+    outfile = data.outdir / "vr.nii.gz"
+    cmd = """
+    3dvolreg
+        -prefix {outfile}
+        -1Dfile {data.outdir}/vr.1D
+        -base 0
+        {infile}
+    """
+    cmd = " ".join(cmd.format(**locals()).split())
+    # run_cmd raises if 3dvolreg exits non-zero
+    tools.run_cmd(data, cmd)
+
+    assert outfile.exists() and outfile.stat().st_size > 0
+    assert nb.load(outfile).shape == (NX, NY, NZ, NT - 1)


### PR DESCRIPTION
Fixes #73.

**Cause.** When a NIfTI file's AFNI extension was written for a different
number of volumes than the header now declares (the file was sliced by
nibabel/nilearn, which carries header extensions over unchanged; MRIQC's
`reorient_and_discard` step in the report), `THD_nifti_process_afni_ext`
prints "dimensions altered since AFNI extension was added" and then still
applies the stale attributes. `THD_datablock_apply_atr` takes `taxis->ntt`
from the extension's `TAXIS_NUMS` while `dblk->nvals` keeps the header's
value, so `DSET_NUM_TIMES` and `DSET_NVALS` disagree. `3dinfo` shows it
directly ("Number of time steps = 204" next to "all 203 sub-bricks" in the
report). Writing such a dataset back out as NIfTI then fails, because
`thd_niftiwrite.c` sets `nim->nt` from `DSET_NUM_TIMES` but builds the brick
list from `DSET_NVALS`, and `nifti_NBL_matches_nim` rejects the pair
("NBL does not match nim"). `3dvolreg` ignored the status of `DSET_write`,
so it exited 0 and left a 0-byte `.nii.gz` behind.

**Fix.**
- `thd_initdblk.c` (`THD_datablock_apply_atr`): after building the time
  axis from `TAXIS_NUMS`, if `ntt` differs from the number of sub-bricks
  actually present, warn and set `ntt = dblk->nvals`. The header is
  authoritative for how many volumes exist; the extension's other
  attributes (labels, history, ...) are still applied as before.
- `3dvolreg.c`: check the return value of `DSET_write` for the output
  dataset (and the `-savedisp` datasets) and `ERROR_exit` on failure, so a
  failed write is never a silent success.

**Test.** `tests/scripts/test_3dvolreg.py` builds a small 4D NIfTI, lets
`3dcalc` add the AFNI extension, drops the last volume with nibabel (keeping
the extension), and checks that `3dinfo -ntimes` equals `-nv`, that
`3dvolreg` succeeds, and that its NIfTI output has N-1 volumes. It fails on
master (`3dvolreg` exits 0, output is empty) and passes with this change.
It needs no external data.

**What was run.** Built `libmri.so`, `3dvolreg`, `3dinfo`, `3dcalc` from
this branch with `Makefile.linux_ubuntu_24_64` (gcc 13.3, Ubuntu 24.04) and
ran the test and a standalone reproduction before and after; both files are
in the link below, together with the output. The full test suite was
not run (it needs the datalad test-data checkout).

Found while working through open issues in Mytochondria, a volunteer project that verifies fixes for the software behind published results (methods and harnesses: https://github.com/cindykrafft/mytochondria/tree/main/audits/afni)

---
_Generated by [Claude Code](https://claude.ai/code)_